### PR TITLE
Fixed Content-Security-Policy issue

### DIFF
--- a/.changeset/fair-moons-sell.md
+++ b/.changeset/fair-moons-sell.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.clonotype-space.ui': patch
+---
+
+Fixed Content-Security-Policy issue

--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="script-src 'self' blob: https: 'unsafe-eval';">
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' blob: https: data: 'unsafe-eval';" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <body>


### PR DESCRIPTION
MSA wouldn't work because `data:` wasn't allowed in Content-Security-Policy settings. This PR fixes that, making it possible to upgrade sdk-ui version.