### PR TITLE
Clonotype Space: use gpu() 

### DIFF
--- a/.changeset/gpu-flag-feats-has-gpu.md
+++ b/.changeset/gpu-flag-feats-has-gpu.md
@@ -1,0 +1,12 @@
+---
+"@platforma-open/milaboratories.clonotype-space": minor
+"@platforma-open/milaboratories.clonotype-space.workflow": minor
+"@platforma-open/milaboratories.clonotype-space.model": minor
+"@platforma-open/milaboratories.clonotype-space.ui": minor
+---
+
+Add GPU acceleration for UMAP via the cuml backend when the platforma backend reports GPU availability.
+
+- New `GPU memory (GB)` field in Performance Settings (default 16, range 1–192). The value is requested only when `feats.hasGpu` is true; on CPU-only backends it is ignored and the calculation falls back to the sklearn UMAP backend, identical to the previous behavior.
+- Workflow gates `.gpuMemory()` and `--umap-backend cuml` on `feats.hasGpu` so the same block runs both on GPU clusters (e.g. AWS EKS with the `kueue.pools.gpu.enabled` pool) and on CPU-only/local installations.
+- Bumps `@platforma-sdk/workflow-tengo` to 5.20.0 (which ships `feats.hasGpu`).

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ software/**/*.tgz
 .DS_Store
 .vscode/sftp.json
 test-dry-run.json
+.idea

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -29,6 +29,7 @@ export type BlockArgs = {
   umap_min_dist: number;
   cpu: number;
   mem: number;
+  gpuMemory: number;
 };
 
 export type UiState = {
@@ -81,6 +82,7 @@ export const model = BlockModel.create()
     umap_min_dist: 0.5,
     mem: 64,
     cpu: 8,
+    gpuMemory: 16,
   })
 
   .withUiState<UiState>({
@@ -103,7 +105,8 @@ export const model = BlockModel.create()
     && ctx.args.umap_neighbors !== undefined
     && ctx.args.umap_min_dist !== undefined
     && ctx.args.mem !== undefined
-    && ctx.args.cpu !== undefined,
+    && ctx.args.cpu !== undefined
+    && ctx.args.gpuMemory !== undefined,
   )
 
   .output('inputOptions', (ctx) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ catalogs:
       specifier: 1.65.10
       version: 1.65.10
     '@platforma-sdk/workflow-tengo':
-      specifier: 5.14.0
-      version: 5.14.0
+      specifier: 5.20.0
+      version: 5.20.0
     '@types/node':
       specifier: ^24.5.2
       version: 24.10.4
@@ -242,7 +242,7 @@ importers:
         version: link:../software/umap
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.14.0
+        version: 5.20.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
@@ -1554,6 +1554,9 @@ packages:
   '@platforma-open/milaboratories.software-ptabler@1.15.2':
     resolution: {integrity: sha512-Tsb7+VldYyyp0m6kTT0Gzw67yX8WECLvgHkaCxCwjvSGpKlvjSjuFcBEPNZ7zjNoFdM7ZrtGu81xrrAVCrUuJw==}
 
+  '@platforma-open/milaboratories.software-ptabler@1.16.1':
+    resolution: {integrity: sha512-m4tzKYlopjHLYpRLSjIqEtFr0QP7MuweaMCTEmr6a+gIVE+x9MKawdXwNwo1A/2QuatygIcGRvIcIz34WibZMA==}
+
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
 
@@ -1612,6 +1615,9 @@ packages:
 
   '@platforma-sdk/workflow-tengo@5.14.0':
     resolution: {integrity: sha512-4k/1/TNQBoQGCfLLQsS2AzYLNdsERcdyFA7Y6pryGm+4OotG5pqU5trjGMeiTBDn2OiGYgBy8cLAHQ0JysK65Q==}
+
+  '@platforma-sdk/workflow-tengo@5.20.0':
+    resolution: {integrity: sha512-NUQI4PYj2BXhIhYgLkQxlDRo5FekgoY+vwOCVzmtFVz9YmCzXTtJC20JkIFuqUAPvkMbKioSsTc9rJm0mzqdHg==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -8534,6 +8540,8 @@ snapshots:
 
   '@platforma-open/milaboratories.software-ptabler@1.15.2': {}
 
+  '@platforma-open/milaboratories.software-ptabler@1.16.1': {}
+
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10': {}
@@ -8634,8 +8642,8 @@ snapshots:
       '@milaboratories/pl-middle-layer': 1.55.19(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-tree': 1.9.14
       '@platforma-sdk/model': 1.65.10
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
-      vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))
+      vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - '@edge-runtime/vm'
@@ -8697,6 +8705,13 @@ snapshots:
     dependencies:
       '@milaboratories/software-pframes-conv': 2.2.9
       '@platforma-open/milaboratories.software-ptabler': 1.15.2
+      '@platforma-open/milaboratories.software-ptexter': 1.2.2
+      '@platforma-open/milaboratories.software-small-binaries': 2.0.4
+
+  '@platforma-sdk/workflow-tengo@5.20.0':
+    dependencies:
+      '@milaboratories/software-pframes-conv': 2.2.9
+      '@platforma-open/milaboratories.software-ptabler': 1.16.1
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
       '@platforma-open/milaboratories.software-small-binaries': 2.0.4
 
@@ -11643,7 +11658,7 @@ snapshots:
       vite: 8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)
       vue: 3.5.26(typescript@5.6.3)
 
-  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3)':
+  '@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -11655,7 +11670,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+      vitest: 4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -14318,7 +14333,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)):
+  vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.3
       '@vitest/mocker': 4.1.3(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
@@ -14342,7 +14357,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.3.2
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 5.14.0
+  '@platforma-sdk/workflow-tengo': 5.20.0
   '@platforma-sdk/model': 1.65.10
   '@platforma-sdk/ui-vue': 1.65.10
   '@platforma-sdk/tengo-builder': 2.5.12

--- a/ui/src/pages/UmapPage.vue
+++ b/ui/src/pages/UmapPage.vue
@@ -296,6 +296,35 @@ watch(
               </template>
             </PlNumberField>
           </div>
+          <div :style="{ display: 'flex', gap: '8px', width: '320px', marginTop: '8px' }">
+            <PlNumberField
+              v-model="app.model.args.gpuMemory"
+              label="GPU memory (GB)"
+              placeholder="16"
+              :min="1"
+              :max="192"
+              :step="1"
+              required
+              :validate="(value) => value === undefined ? 'GPU memory is required' : undefined"
+              :style="{ flex: 1 }"
+            >
+              <template #tooltip>
+                <div>
+                  <strong>GPU Memory for UMAP Calculation</strong><br>
+                  Set the amount of GPU memory (in GB) to request when a GPU is available on the backend.
+                  When the backend reports no GPU, this value is ignored and the calculation runs on CPU
+                  (sklearn UMAP backend).<br><br>
+                  <strong>Default:</strong> 16 GB<br><br>
+                  <strong>Recommended:</strong><br>
+                  • Small datasets (&lt; 10k clonotypes): <strong>3-6 GB</strong><br>
+                  • Medium datasets (10k - 100k): <strong>12-24 GB</strong><br>
+                  • Large datasets (&gt; 100k): <strong>24-48 GB</strong><br><br>
+                  Larger requests route to bigger GPU instances. On AWS the cluster has tiers at
+                  3, 6, 12, 24, 48 and 192 GiB VRAM — your request lands on the smallest tier that fits.
+                </div>
+              </template>
+            </PlNumberField>
+          </div>
         </PlAccordionSection>
         <PlAlert v-if="isEmpty === true" type="warn" :style="{ width: '320px' }">
           <template #title>Empty dataset selection</template>

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -74,6 +74,7 @@ wf.body(func(args) {
 
 	mem := args.mem
 	cpu := args.cpu
+	gpuMemory := args.gpuMemory
 
 	// Call UMAP calculation subtemplate
 	umapRender := render.create(umapCalculationTpl, {
@@ -82,7 +83,8 @@ wf.body(func(args) {
 		umap_min_dist: umap_min_dist,
 		alphabet: alphabet,
 		mem: mem,
-		cpu: cpu
+		cpu: cpu,
+		gpuMemory: gpuMemory
 	})
 
 	// Get UMAP file and stdout stream from subtemplate

--- a/workflow/src/umap-calculation.tpl.tengo
+++ b/workflow/src/umap-calculation.tpl.tengo
@@ -3,6 +3,7 @@
 self := import("@platforma-sdk/workflow-tengo:tpl")
 exec := import("@platforma-sdk/workflow-tengo:exec")
 assets := import("@platforma-sdk/workflow-tengo:assets")
+feats := import("@platforma-sdk/workflow-tengo:feats")
 
 self.defineOutputs("umapTsVFile", "umapOutput")
 
@@ -24,10 +25,19 @@ self.body(func(args) {
     // UMAP software execution
     // Note: --seq-col-start "sequence" will match all columns starting with "sequence"
     // (sequence.TRA, sequence.TRB, sequence_0, etc.)
-    umapClones := exec.builder().
+    builder := exec.builder().
         software(assets.importSoftware("@platforma-open/milaboratories.clonotype-space.umap:main")).
         mem(string(mem) + "GiB").
-        cpu(cpu).
+        cpu(cpu)
+
+    // Request GPU only when the backend reports one. .gpuMemory() against a
+    // backend without GPU is a hard error, so we MUST gate with feats.hasGpu.
+    // The umap software falls back to sklearn on CPU when --umap-backend=auto.
+    if feats.hasGpu {
+        builder = builder.gpuMemory("16GiB")
+    }
+
+    umapClones := builder.
         addFile("sequences.tsv", umapTable).
         arg("-i").arg("sequences.tsv").
         arg("-c").arg("sequence").

--- a/workflow/src/umap-calculation.tpl.tengo
+++ b/workflow/src/umap-calculation.tpl.tengo
@@ -15,6 +15,7 @@ self.body(func(args) {
     alphabet := args.alphabet
     mem := args.mem
     cpu := args.cpu
+    gpuMemory := args.gpuMemory
 
     // Calculate k-mer size based on alphabet
     kmerSize := 3 // default for aminoacid
@@ -28,16 +29,7 @@ self.body(func(args) {
     builder := exec.builder().
         software(assets.importSoftware("@platforma-open/milaboratories.clonotype-space.umap:main")).
         mem(string(mem) + "GiB").
-        cpu(cpu)
-
-    // Request GPU only when the backend reports one. .gpuMemory() against a
-    // backend without GPU is a hard error, so we MUST gate with feats.hasGpu.
-    // The umap software falls back to sklearn on CPU when --umap-backend=auto.
-    if feats.hasGpu {
-        builder = builder.gpuMemory("16GiB")
-    }
-
-    umapClones := builder.
+        cpu(cpu).
         addFile("sequences.tsv", umapTable).
         arg("-i").arg("sequences.tsv").
         arg("-c").arg("sequence").
@@ -46,7 +38,19 @@ self.body(func(args) {
         arg("--umap-min-dist").arg(string(umap_min_dist)).
         arg("--alphabet").arg(alphabet).
         arg("--k-mer-size").arg(string(kmerSize)).
-        arg("--n-jobs").arg(string(cpu)).
+        arg("--n-jobs").arg(string(cpu))
+
+    // Request GPU only when the backend reports one. .gpuMemory() against a
+    // backend without GPU is a hard error, so we MUST gate with feats.hasGpu.
+    // When GPU is available, force the cuml backend; otherwise let the
+    // software auto-select (sklearn on CPU).
+    if feats.hasGpu {
+        builder = builder.
+            gpuMemory(string(gpuMemory) + "GiB").
+            arg("--umap-backend").arg("cuml")
+    }
+
+    umapClones := builder.
         saveFile("umap.tsv").
         saveFile("skipped_clonotypes_summary.txt").
         saveStdoutStream().


### PR DESCRIPTION
## Summary

The umap step now opts into GPU only when the backend reports one available via `feats.hasGpu`. When `feats.hasGpu` is true, requests 16 GiB of GPU memory; otherwise the block runs on CPU as before. The umap software's `--umap-backend` defaults to `auto` and falls back to sklearn on CPU.

Without this guard, calling `.gpuMemory()` against a non-GPU backend produces a permanent error from the runner driver.

Pairs with:
- [milaboratory/pl#1800](https://github.com/milaboratory/pl/pull/1800) — backend `--runner-gpu-available` flag
- [milaboratory/platforma#TBD](https://github.com/milaboratory/platforma) — `feats.hasGpu` in `@platforma-sdk/workflow-tengo`

Requires `@platforma-sdk/workflow-tengo` with `feats.hasGpu` to be released and bumped here before merge.

## Test plan

- [x] `pnpm build` succeeds end-to-end (workflow + ui + block-pack)
- [ ] Run on a CPU-only backend: confirms `--umap-backend auto` path, no GPU request emitted
- [ ] Run on a GPU backend (K8s/EKS with `kueue.pools.gpu.enabled=true`): confirms GPU is requested, job lands on a g6 node, `cuml` backend used
- [ ] Tune `gpuMemory` size (currently 16 GiB placeholder — depends on dataset size)