### PR TITLE
Julenmendieta/MILAB-6251_adaptToShortPeptides

### DIFF
--- a/.changeset/lemon-dragons-battle.md
+++ b/.changeset/lemon-dragons-battle.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.clonotype-space.umap": minor
+"@platforma-open/milaboratories.clonotype-space.workflow": minor
+"@platforma-open/milaboratories.clonotype-space": minor
+---
+
+Positional k-mer encoder for short peptides

--- a/block/package.json
+++ b/block/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "shx rm -rf ./block-pack && block-tools pack",
     "mark-stable": "block-tools mark-stable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
-    "prepublishOnly": "block-tools pack && block-tools publish --unstable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
+    "prepublishOnly": "block-tools pack && block-tools publish -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
     "do-pack": "shx rm -f *.tgz && block-tools pack && pnpm pack && shx mv *.tgz package.tgz"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,20 +10,20 @@ catalogs:
       specifier: ^2.29.8
       version: 2.29.8
     '@milaboratories/graph-maker':
-      specifier: 1.4.1
-      version: 1.4.1
+      specifier: 1.4.3
+      version: 1.4.3
     '@milaboratories/helpers':
       specifier: 1.14.2
       version: 1.14.2
     '@milaboratories/multi-sequence-alignment':
-      specifier: 1.47.12
-      version: 1.47.12
+      specifier: 1.47.13
+      version: 1.47.13
     '@milaboratories/strings':
       specifier: 0.1.2
       version: 0.1.2
     '@milaboratories/ts-builder':
-      specifier: 1.4.0
-      version: 1.4.0
+      specifier: 1.5.0
+      version: 1.5.0
     '@milaboratories/ts-configs':
       specifier: 1.2.3
       version: 1.2.3
@@ -31,29 +31,29 @@ catalogs:
       specifier: 1.7.9
       version: 1.7.9
     '@platforma-sdk/block-tools':
-      specifier: 2.8.1
-      version: 2.8.1
+      specifier: 2.8.2
+      version: 2.8.2
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.76.5
-      version: 1.76.5
+      specifier: 1.77.4
+      version: 1.77.4
     '@platforma-sdk/package-builder':
       specifier: 3.12.0
       version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 2.5.29
-      version: 2.5.29
+      specifier: 3.0.2
+      version: 3.0.2
     '@platforma-sdk/test':
-      specifier: 1.76.6
-      version: 1.76.6
+      specifier: 1.77.7
+      version: 1.77.7
     '@platforma-sdk/ui-vue':
-      specifier: 1.76.5
-      version: 1.76.5
+      specifier: 1.77.4
+      version: 1.77.4
     '@platforma-sdk/workflow-tengo':
-      specifier: 5.23.0
-      version: 5.23.0
+      specifier: 5.25.0
+      version: 5.25.0
     '@types/node':
       specifier: ^24.5.2
       version: 24.10.4
@@ -91,7 +91,7 @@ importers:
         version: 2.29.8(@types/node@25.0.3)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.1
+        version: 2.8.2
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -115,33 +115,33 @@ importers:
         version: link:../workflow
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.76.5
+        version: 1.77.4
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.1
+        version: 2.8.2
 
   model:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.76.5)(@platforma-sdk/ui-vue@1.76.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.76.5
+        version: 1.77.4
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.4.0(@types/node@24.10.4)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.5.0(@types/node@24.10.4)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.1
+        version: 2.8.2
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.15.0)(typescript-eslint@8.51.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
@@ -175,7 +175,7 @@ importers:
     devDependencies:
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.76.6(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+        version: 1.77.7(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -187,13 +187,13 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.76.5)(@platforma-sdk/ui-vue@1.76.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.12(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.76.5)(@platforma-sdk/ui-vue@1.76.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -202,10 +202,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.76.5
+        version: 1.77.4
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.76.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@vueuse/core':
         specifier: 'catalog:'
         version: 13.9.0(vue@3.5.24(typescript@5.6.3))
@@ -215,7 +215,7 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.4.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.5.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
         version: 1.2.3
@@ -242,11 +242,11 @@ importers:
         version: link:../software/umap
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.23.0
+        version: 5.25.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.5.29
+        version: 3.0.2
 
 packages:
 
@@ -1159,8 +1159,8 @@ packages:
     resolution: {integrity: sha512-MgUqC3/8cE41k01dV8yne+K0bUYA457XFP7b/Sf5QrxDp6zWqCpWuCgLlsUzJNzFFLXaODWnpAFUvOZyQcq4jg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/graph-maker@1.4.1':
-    resolution: {integrity: sha512-zeQOMrzfpplu2vynBLyEEfK6aRI1Tzhge1z+8c75ZJ5VSDB+VgVG7NzioFQ7qyEN3as3XPlPFQ60Y323Sj5QIw==}
+  '@milaboratories/graph-maker@1.4.3':
+    resolution: {integrity: sha512-67FjRlIolHpMLQYKgvHxjmZXe9bijVvM0vyfgrzwvXW51FxtREpiRjwBJWbmnAALw++vcrLVhuN+lAyhVpSQfw==}
     peerDependencies:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
@@ -1173,27 +1173,27 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/miplots4@1.2.0':
-    resolution: {integrity: sha512-tUJkqB6yCj/HxSrxWvmiCulluPwhIy1538e93cz/P9t2OqAXCumkyGbXwNKwwSRxitiVVjqG26rZbMQBctykdA==}
+  '@milaboratories/miplots4@1.2.1':
+    resolution: {integrity: sha512-W9a9bVbW/zsHWSVadhK1ZETdXLdfhrzdPaig9Mr/6Nl9Hn0oHEX94D6pXCgGyfGV5zi7h/rY1pB0l7YUmsP3uA==}
 
-  '@milaboratories/multi-sequence-alignment@1.47.12':
-    resolution: {integrity: sha512-K0blTkxdxEi1ZWrTUAlSpqqBK9Kj2rZvs8SX+p56p9Z6bjg6CAZa3PYC7zCgggwZamP+S0rTziuha9W9cWZwUw==}
+  '@milaboratories/multi-sequence-alignment@1.47.13':
+    resolution: {integrity: sha512-71PbFOil/+uPOurkkMtj/+9pYMLfx8o79bBgXCw0b98OYBTMseGXYw94vFemPqsFnZX2mVk6kwm/1oz41gZhxg==}
     peerDependencies:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
 
-  '@milaboratories/pf-driver@1.4.11':
-    resolution: {integrity: sha512-HBXt9vusZcMf0p4diAvZFoF+EXtxa67B4dKGIQJ/PMySYxfmW7OrZhgoXg/1zXVlucYvOp289ow0scaF+N0TlQ==}
+  '@milaboratories/pf-driver@1.4.12':
+    resolution: {integrity: sha512-KVe2guqrvmQxaqGIfmfwiGzYkoiBDZBUp50zlnbWygxuZx4A2VuVDMYr66BkaYAnmxcCXq/Fm5YCwpYqtcH54Q==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pf-plots@1.4.1':
-    resolution: {integrity: sha512-qcJ/vzZLtxBi4mPGAvM1vQuBZfC2YYHLTTkJbsJUeWwfOjQg/YEuxoHkN58LXHnd6s0pcc7clAtpwdq0Y8JONQ==}
+  '@milaboratories/pf-plots@1.4.2':
+    resolution: {integrity: sha512-c24NW5LVAgj5j7WhM+8i3yT1G9l4sOLtqgkOCN/uWFQu3aReArzLOHNXjvztSk1pVPQZP9QjOCgKObOBHh9sDg==}
     peerDependencies:
       '@milaboratories/pl-model-common': 1.39.0
       '@platforma-sdk/model': 1.73.3
 
-  '@milaboratories/pf-spec-driver@1.3.16':
-    resolution: {integrity: sha512-Podb1eNvcl1nQXG/LeT+ZiesSq17z4ixBNDk0Kj92RRYQ6IZDeDyCgUgrVH7/A/UZ/j/dyRzbjkOLBWmk3DDmQ==}
+  '@milaboratories/pf-spec-driver@1.3.17':
+    resolution: {integrity: sha512-ShmOxNr8ocgZJiOaSC1bD23L1+oqwiaPS5Hh8Bqa9FO1FP7DWPMWV0LtVuUr7ZRGLzivjh9ccQbMyK9QuP5pbg==}
 
   '@milaboratories/pframes-rs-node@1.1.35':
     resolution: {integrity: sha512-XGLRa29bOmpEUeHgpWNDYZDGDFvR7OfXqaodxaIAVtXnsrsjxzDz063z1sjRPDOx/Pz9T+5n4iRNuLyygwcQ5A==}
@@ -1212,23 +1212,19 @@ packages:
       '@milaboratories/pl-model-common': 1.36.0
       '@milaboratories/pl-model-middle-layer': 1.18.5
 
-  '@milaboratories/pl-client@3.5.0':
-    resolution: {integrity: sha512-eVDnXExhKB4DYzqkWD49MYyi6AyBxWyG8WoDMFrB23FjyHgMTR7rSoep0iUsWEoLLGnwq4Qd8l89/hBYpAVg0A==}
-    engines: {node: '>=22.19.0'}
-
-  '@milaboratories/pl-client@3.8.0':
-    resolution: {integrity: sha512-ADUFHvwtGDC/sOYd4btCw2GdR58gq3+Nm9yV3UUYhmH5dv3J/1tXsxJH15mv1mT9YvK0IS4vMw0eDteeQUmaiQ==}
+  '@milaboratories/pl-client@3.8.1':
+    resolution: {integrity: sha512-x2Y1xooxtEttIfj60JSGMUDdTsAk3RrmlOmuuytwgq82RfDpAAa1M1XHBfuCUNoAjDP1e6BgU9rk4ZhOMGBf9A==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-config@1.8.1':
     resolution: {integrity: sha512-moh8YNeSXRkBaH5IQhrzcWoehM6EMwfVFx2Y4vP6eEwphbHDqPLdhn6COkEJlYijH6kT00JdWjlUrvx+MZD9Cw==}
 
-  '@milaboratories/pl-deployments@2.17.17':
-    resolution: {integrity: sha512-4RbNi5KAasMhm7YvyZIRxA/o8x7MBMfoZOhstDSd+KKOBmi5Ve/hX+yvJmiVbwvkO/ApQk7Ay+ic+4at8J5fSg==}
+  '@milaboratories/pl-deployments@3.0.0':
+    resolution: {integrity: sha512-M3QMHGA9QBf+/rsxKRUzg/qf+K1I3i0Yq1gDXGuXgNK22PS+Wua5aUAlKsM5gSz+MqesAlbaupLF802Kqrt/QA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.14.7':
-    resolution: {integrity: sha512-FJhnr6zOkFUIuYG5jzMGYY0qfM7wydUET75s1uJ/iJ+xboFdm+kMCKLq/OfYYcQdbGMZLQr5F5kOvFW4xoC8Rg==}
+  '@milaboratories/pl-drivers@1.14.11':
+    resolution: {integrity: sha512-6C2oZ/ZERPJ051+8tu72XyKiOqHKstipGqRdg7tz4/R0/reTF6Jqpb5gLpsvnZBlDPaPyird0dtdVWs/8VZXFQ==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
@@ -1237,21 +1233,22 @@ packages:
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
 
-  '@milaboratories/pl-errors@1.4.7':
-    resolution: {integrity: sha512-YUP3KZc/m3N7+oPQTh2+2ZKjyQERRDVt1mXiQUPgZ0uMUHZDzK8q6INkvvDUGqQlBsAPLIxzO7PS2tW84ZpOBA==}
+  '@milaboratories/pl-errors@1.4.11':
+    resolution: {integrity: sha512-9GbMsSXxRosjRnF2L3usGcAa3v05lbN30PBDDeqpZUA0w5taUTwJKu2I4mhwx9Vs2WvHTXJEbCgmR/DRA50L8w==}
+
+  '@milaboratories/pl-healthcheck@1.0.0':
+    resolution: {integrity: sha512-tuSg+bwacmt9Z5gOkiarmX7jwYJttA+9rqXKaatwnPgjP+nAI40hyZtOZPHzJFEzWd4AKaGxrJbNxdB/xMG/ww==}
+    engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.60.0':
-    resolution: {integrity: sha512-hwoMgdtXVs3LnOI7Y8EILGrYOorcjKGuU7nyGtxXQuP5z8VEH5y7Vd631yr1Fa9DcxqfssENuPtFYLLAUSOBzQ==}
+  '@milaboratories/pl-middle-layer@1.61.3':
+    resolution: {integrity: sha512-gVJTLnVtBa/xEPrXiuDJmMM0rzbKXRL2S2YmfWLOfA8SdKyS6kMVfWQAsuea8Ee/ojSQcLfZmS9bcxUZ1ga/nA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.2.29':
-    resolution: {integrity: sha512-0jL+k6z6MJha0XMFXq/e814THyvNZZNeBB6zcLYtiWKVYRCKp/iK43xOFCzGAgT1uQVz4AdhKsqgqQv5B9deBw==}
-
-  '@milaboratories/pl-model-backend@1.3.1':
-    resolution: {integrity: sha512-zDWTa/AqI2YSmD3FpQavWI9OnZzMRoNQS+E8YtdSadC9LkvetqY5YI9Uu/IAGrWVonlvjD6uA0PrPX5hACOxow==}
+  '@milaboratories/pl-model-backend@1.3.2':
+    resolution: {integrity: sha512-1w4Jcl2vk7w8foWztKthDryQCPrkefW+5hXIwSNsNIB40o0v83p4zoqMGBrrm9b2MJUPoFyliTkAsp+J1UQu9g==}
 
   '@milaboratories/pl-model-common@1.36.0':
     resolution: {integrity: sha512-BbFs3sTmy12ZKfTY6rFep0C5pfQoLvsjACN8EYaNIjXqOjQajt6velh4uGpB47+Uyp78k0cIWH4T04MIlixQrw==}
@@ -1262,14 +1259,11 @@ packages:
   '@milaboratories/pl-model-middle-layer@1.18.5':
     resolution: {integrity: sha512-eIYE77rBva0k2KWDUmKJBHnGcyi/Tnc5rhlwZVb8q3hS3L4Upf4Pk7/lBL4ZLxYVMZ3/Da0Wp3EKYspUagi9Zg==}
 
-  '@milaboratories/pl-model-middle-layer@1.19.4':
-    resolution: {integrity: sha512-2SzgfHmTpSewPAv3WqbS6XHpObh69Mull3b1ec2bhn11ij6zSEDcBrMz0fFQ1XViAVQcafC4CjNTDZ/6s92kgQ==}
-
   '@milaboratories/pl-model-middle-layer@1.20.0':
     resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
 
-  '@milaboratories/pl-tree@1.11.0':
-    resolution: {integrity: sha512-L6GYK0fff9ZsuZcuKW1wbu7uJl4I1S6zRhp4bpcnuCcLZuo3Qqf3zvmvax2bAl7e/rsRa6cMhz409PXS0c5Cww==}
+  '@milaboratories/pl-tree@1.12.1':
+    resolution: {integrity: sha512-fUsW5VJFCGwuCL8x0cLXhRxkCCVGu3Dj49eFd470l/xKHuCJvCZjJ6QpUAkIyJLkvxNORXhAIFoaOAPyzul+pQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/ptabler-expression-js@1.2.25':
@@ -1289,8 +1283,8 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
-  '@milaboratories/ts-builder@1.4.0':
-    resolution: {integrity: sha512-Qh6xH5/WqshVfwLqNrV5PjPdf6vzEj2AtVNCmHdiG8Q/61D03W2YuDY8+2aXwAvg3tYD5tJ2Fv+ahmntNKGhlA==}
+  '@milaboratories/ts-builder@1.5.0':
+    resolution: {integrity: sha512-tSLwqZ5dfmiXwriCYh2LI++N3AfB2RR5E30TSQRYd1ovC9fMZ9eGCZ3WskQ1h0p5+dUeSKGkDlgZFNF1wO1TTQ==}
     hasBin: true
 
   '@milaboratories/ts-configs@1.2.3':
@@ -1303,8 +1297,8 @@ packages:
     resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.14.9':
-    resolution: {integrity: sha512-a1geGq7uVV6hg6BvAwjmDVzE6fRTFSihOvRUdVXLZSQPMc8KUI2qOP/SQxFXVQauEffoktCFts7I6LZXkuHYpw==}
+  '@milaboratories/uikit@2.14.11':
+    resolution: {integrity: sha512-6I20gxijl8AKIZFWDItWs6cut+v3G0sN3uOhUVTrRW8V77B+f/8e8+HKs+b9F/r5QQ0xP6nJN2nuO+a/EblZcw==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -1456,43 +1450,117 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/darwin-arm64@1.43.0':
-    resolution: {integrity: sha512-C/GhObv/pQZg34NOzB6Mk8x0wc9AKj8fXzJF8ZRKTsBPyHusC6AZ6bba0QG0TUufw1KWuD0j++oebQfWeiFXNw==}
+  '@oxlint/binding-android-arm-eabi@1.63.0':
+    resolution: {integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.63.0':
+    resolution: {integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.63.0':
+    resolution: {integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/darwin-x64@1.43.0':
-    resolution: {integrity: sha512-4NjfUtEEH8ewRQ2KlZGmm6DyrvypMdHwBnQT92vD0dLScNOQzr0V9O8Ua4IWXdeCNl/XMVhAV3h4/3YEYern5A==}
+  '@oxlint/binding-darwin-x64@1.63.0':
+    resolution: {integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/linux-arm64-gnu@1.43.0':
-    resolution: {integrity: sha512-75tf1HvwdZ3ebk83yMbSB+moAEWK98mYqpXiaFAi6Zshie7r+Cx5PLXZFUEqkscenoZ+fcNXakHxfn94V6nf1g==}
+  '@oxlint/binding-freebsd-x64@1.63.0':
+    resolution: {integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
+    resolution: {integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
+    resolution: {integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
+    resolution: {integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/linux-arm64-musl@1.43.0':
-    resolution: {integrity: sha512-BHV4fb36T2p/7bpA9fiJ5ayt7oJbiYX10nklW5arYp4l9/9yG/FQC5J4G1evzbJ/YbipF9UH0vYBAm5xbqGrvw==}
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
+    resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/linux-x64-gnu@1.43.0':
-    resolution: {integrity: sha512-1l3nvnzWWse1YHibzZ4HQXdF/ibfbKZhp9IguElni3bBqEyPEyurzZ0ikWynDxKGXqZa+UNXTFuU1NRVX1RJ3g==}
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+    resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+    resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+    resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+    resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
+    resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/linux-x64-musl@1.43.0':
-    resolution: {integrity: sha512-+jNYgLGRFTJxJuaSOZJBwlYo5M0TWRw0+3y5MHOL4ArrIdHyCthg6r4RbVWrsR1qUfUE1VSSHQ2bfbC99RXqMg==}
+  '@oxlint/binding-linux-x64-musl@1.63.0':
+    resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/win32-arm64@1.43.0':
-    resolution: {integrity: sha512-dvs1C/HCjCyGTURMagiHprsOvVTT3omDiSzi5Qw0D4QFJ1pEaNlfBhVnOUYgUfS6O7Mcmj4+G+sidRsQcWQ/kA==}
+  '@oxlint/binding-openharmony-arm64@1.63.0':
+    resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
+    resolution: {integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/win32-x64@1.43.0':
-    resolution: {integrity: sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA==}
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+    resolution: {integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
+    resolution: {integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -1579,12 +1647,8 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.0.4':
     resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
 
-  '@platforma-sdk/block-tools@2.7.25':
-    resolution: {integrity: sha512-7msHgkgr3uFTitgokcOFAqdO9mtAUr9rHnmjk26WzIzO1HY/uyrs2AHWpdc/skchJHr1U7HHzNt7oQ3RdzZWpQ==}
-    hasBin: true
-
-  '@platforma-sdk/block-tools@2.8.1':
-    resolution: {integrity: sha512-5PA8iAdndsxlbk4YMAJDnueFBNracOHPDV8a6Zw10mkxP6+YFvsnlA4+kJoh7ULTgI6qPpLmCYwvPdA6KFwd7g==}
+  '@platforma-sdk/block-tools@2.8.2':
+    resolution: {integrity: sha512-9+rqqx0XAWNfo+P6rA95UqRFMLZckbZ3W/xPi53zt+vYqgCLehZM+KnGROOk0w5NxiTsudB2JJSbeM2WyQUnxQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1603,26 +1667,26 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.76.5':
-    resolution: {integrity: sha512-CFrzfOW9cc4ZLQ8p/BcfX+XUBy5jJLvWM80534vCf9t8hQgXNMLvXs0jxzR5AuY7QZvN5/mpT17OMZTYU5l5Vg==}
+  '@platforma-sdk/model@1.77.4':
+    resolution: {integrity: sha512-YJ/IsURqdaNnOf9JNw8dfmwaZQz1JhEqqR76jK7tmEH7y5ZOKB8mc5Hp3A/x7Wp/9JcXLAVY84h8s6R86FPl4w==}
 
   '@platforma-sdk/package-builder@3.12.0':
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@2.5.29':
-    resolution: {integrity: sha512-iurwyuFCq1DynPuoud182Ebdrk8dhSjLddkOSvPQb1QZ+HVU/CcEfIx0SgZ+qOLstHQ1lB2YeHv7GCaMHsjI9A==}
+  '@platforma-sdk/tengo-builder@3.0.2':
+    resolution: {integrity: sha512-v1g1SOtZDrCuIcvrlqwsaf3stCHsrV8wuoOgl8ok67fX+9cJtT/QU6NIv+qfog0uukHEjHxourwcu+w0Moz6GQ==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.76.6':
-    resolution: {integrity: sha512-ZFf5Q/pDL2Fc3bitzkOyIsk7GaIquGV3goQPdveCYaTqtueWIEecs/Cm+gcYBChXPSCXQcdG5kRnxxLWaYveyA==}
+  '@platforma-sdk/test@1.77.7':
+    resolution: {integrity: sha512-4WNofxN9aiOg3jcNKESQqwO2KAGQXKJq76EePxiaZM3hsJsI+SjpPorzjwx/Jj4VBJVCWhpX8H4x05gJJDQodA==}
 
-  '@platforma-sdk/ui-vue@1.76.5':
-    resolution: {integrity: sha512-RfYswL09jWC510sRgSkwyXjFZwNq1YnZSkNhht0YQGII4JYALO2nZDOxYPR2GJT1nXSfx9NQ2z0SI6Nm4dgS6g==}
+  '@platforma-sdk/ui-vue@1.77.4':
+    resolution: {integrity: sha512-7P0+OGqu/BMhuvSqeEi/aBrrA9yCGPhs6jmcJlnP/rqCtwz2+M/CTvaYji7zI5U1htpiN877DdfKezdWUj43oA==}
 
-  '@platforma-sdk/workflow-tengo@5.23.0':
-    resolution: {integrity: sha512-ILLn9V7jOWQ8lOdY00X8bvtHeanwgqOPWm/mgT0fvozt1HZSci0z1dp50GpquoETenEeTlDuY1fHAv4qx4roPg==}
+  '@platforma-sdk/workflow-tengo@5.25.0':
+    resolution: {integrity: sha512-uLRwbgq7tHUVtQ+y+iVe40Cf2S9ept8+Q0dBGVlegvxsAqQPOQxhQkkHYvbH6zLmaf237bISME1rL1MxRs2ujQ==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -5516,12 +5580,16 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint@1.43.0:
-    resolution: {integrity: sha512-xiqTCsKZch+R61DPCjyqUVP2MhkQlRRYxLRBeBDi+dtQJ90MOgdcjIktvDCgXz0bgtx94EQzHEndsizZjMX2OA==}
+  oxlint-plugin-eslint@1.63.0:
+    resolution: {integrity: sha512-mb3mlDkQTIzQm0TWvW1n13srNKek3mc4fWNaGsveITlIkKMOi8499rT5B2ZFQDw2+G3LKvjNYkUKIt+OfECqPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxlint@1.63.0:
+    resolution: {integrity: sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.11.2'
+      oxlint-tsgolint: '>=0.22.1'
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
@@ -7889,14 +7957,14 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.76.5)(@platforma-sdk/ui-vue@1.76.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.9
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/miplots4': 1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.76.5)
-      '@platforma-sdk/model': 1.76.5
-      '@platforma-sdk/ui-vue': 1.76.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)
+      '@platforma-sdk/model': 1.77.4
+      '@platforma-sdk/ui-vue': 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.9.0(vue@3.5.26(typescript@5.6.3))
@@ -7917,7 +7985,7 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/miplots4@1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
+  '@milaboratories/miplots4@1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
       '@d3fc/d3fc-chart': 5.1.9(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
       '@d3fc/d3fc-pointer': 3.0.3(d3-dispatch@3.0.1)(d3-selection@3.0.0)
@@ -7955,13 +8023,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.12(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.76.5)(@platforma-sdk/ui-vue@1.76.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.3
-      '@milaboratories/miplots4': 1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.76.5)
-      '@platforma-sdk/model': 1.76.5
-      '@platforma-sdk/ui-vue': 1.76.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)
+      '@platforma-sdk/model': 1.77.4
+      '@platforma-sdk/ui-vue': 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.26(typescript@5.6.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -7971,13 +8039,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/pf-driver@1.4.11(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.4.12(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pframes-rs-node': 1.1.35
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.19.4)
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.19.4
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/ts-helpers': 1.8.2
       es-toolkit: 1.43.0
       lru-cache: 11.2.4
@@ -7986,20 +8054,20 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.76.5)':
+  '@milaboratories/pf-plots@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.42.0
-      '@platforma-sdk/model': 1.76.5
+      '@platforma-sdk/model': 1.77.4
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-spec-driver@1.3.16(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.3.17(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.19.4)
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.19.4
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -8025,32 +8093,14 @@ snapshots:
 
   '@milaboratories/pframes-rs-wasip2@1.1.35': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.19.4)':
+  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
       '@milaboratories/pframes-rs-wasip2': 1.1.35
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.19.4
+      '@milaboratories/pl-model-middle-layer': 1.20.0
 
-  '@milaboratories/pl-client@3.5.0':
-    dependencies:
-      '@grpc/grpc-js': 1.13.4
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/ts-helpers': 1.8.2
-      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
-      '@protobuf-ts/runtime': 2.11.1
-      '@protobuf-ts/runtime-rpc': 2.11.1
-      canonicalize: 2.1.0
-      denque: 2.1.0
-      long: 5.3.2
-      lru-cache: 11.2.4
-      openapi-fetch: 0.15.0
-      undici: 7.16.0
-      utility-types: 3.11.0
-      yaml: 2.8.2
-
-  '@milaboratories/pl-client@3.8.0':
+  '@milaboratories/pl-client@3.8.1':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
@@ -8074,9 +8124,10 @@ snapshots:
       upath: 2.0.1
       yaml: 2.8.2
 
-  '@milaboratories/pl-deployments@2.17.17':
+  '@milaboratories/pl-deployments@3.0.0':
     dependencies:
       '@milaboratories/pl-config': 1.8.1
+      '@milaboratories/pl-healthcheck': 1.0.0
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-common': 1.42.0
       '@milaboratories/ts-helpers': 1.8.2
@@ -8088,14 +8139,14 @@ snapshots:
       yaml: 2.8.2
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.14.7':
+  '@milaboratories/pl-drivers@1.14.11':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/computable': 2.9.4
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-client': 3.5.0
+      '@milaboratories/pl-client': 3.8.1
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-tree': 1.11.0
+      '@milaboratories/pl-tree': 1.12.1
       '@milaboratories/ts-helpers': 1.8.2
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
@@ -8123,38 +8174,46 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-errors@1.4.7':
+  '@milaboratories/pl-errors@1.4.11':
     dependencies:
-      '@milaboratories/pl-client': 3.5.0
+      '@milaboratories/pl-client': 3.8.1
       '@milaboratories/ts-helpers': 1.8.2
       zod: 3.25.76
+
+  '@milaboratories/pl-healthcheck@1.0.0':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
 
   '@milaboratories/pl-http@1.2.4':
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.60.0(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pl-middle-layer@1.61.3(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/computable': 2.9.4
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pf-driver': 1.4.11(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.3.16(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-driver': 1.4.12(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.3.17(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pframes-rs-node': 1.1.35
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.19.4)
-      '@milaboratories/pl-client': 3.5.0
-      '@milaboratories/pl-deployments': 2.17.17
-      '@milaboratories/pl-drivers': 1.14.7
-      '@milaboratories/pl-errors': 1.4.7
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
+      '@milaboratories/pl-client': 3.8.1
+      '@milaboratories/pl-deployments': 3.0.0
+      '@milaboratories/pl-drivers': 1.14.11
+      '@milaboratories/pl-errors': 1.4.11
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.2.29
+      '@milaboratories/pl-model-backend': 1.3.2
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.19.4
-      '@milaboratories/pl-tree': 1.11.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-tree': 1.12.1
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
-      '@platforma-sdk/block-tools': 2.7.25
-      '@platforma-sdk/model': 1.76.5
-      '@platforma-sdk/workflow-tengo': 5.23.0
+      '@platforma-sdk/block-tools': 2.8.2
+      '@platforma-sdk/model': 1.77.4
+      '@platforma-sdk/workflow-tengo': 5.25.0
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.43.0
@@ -8173,15 +8232,9 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.2.29':
+  '@milaboratories/pl-model-backend@1.3.2':
     dependencies:
-      '@milaboratories/pl-client': 3.5.0
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-backend@1.3.1':
-    dependencies:
-      '@milaboratories/pl-client': 3.8.0
+      '@milaboratories/pl-client': 3.8.1
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -8207,14 +8260,6 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.19.4':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
-      es-toolkit: 1.43.0
-      utility-types: 3.11.0
-      zod: 3.25.76
-
   '@milaboratories/pl-model-middle-layer@1.20.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
@@ -8223,11 +8268,11 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.11.0':
+  '@milaboratories/pl-tree@1.12.1':
     dependencies:
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/pl-client': 3.5.0
-      '@milaboratories/pl-errors': 1.4.7
+      '@milaboratories/pl-client': 3.8.1
+      '@milaboratories/pl-errors': 1.4.11
       '@milaboratories/ts-helpers': 1.8.2
       denque: 2.1.0
       utility-types: 3.11.0
@@ -8245,16 +8290,17 @@ snapshots:
 
   '@milaboratories/tengo-tester@1.6.4': {}
 
-  '@milaboratories/ts-builder@1.4.0(@types/node@24.10.4)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.5.0(@types/node@24.10.4)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)':
     dependencies:
       '@milaboratories/ts-configs': 1.2.3
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.26(typescript@5.6.3))
       commander: 12.1.0
       jsonc-parser: 3.3.1
       oxfmt: 0.35.0
-      oxlint: 1.43.0
+      oxlint: 1.63.0
+      oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.13
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.10.4)(rollup@4.55.1)
       typescript: 5.9.3
@@ -8285,16 +8331,17 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-builder@1.4.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.5.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.2)':
     dependencies:
       '@milaboratories/ts-configs': 1.2.3
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.24(typescript@5.6.3))
       commander: 12.1.0
       jsonc-parser: 3.3.1
       oxfmt: 0.35.0
-      oxlint: 1.43.0
+      oxlint: 1.63.0
+      oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.13
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@25.0.3)(rollup@4.55.1)
       typescript: 5.9.3
@@ -8338,10 +8385,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.14.9(typescript@5.6.3)':
+  '@milaboratories/uikit@2.14.11(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.76.5
+      '@platforma-sdk/model': 1.77.4
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8477,28 +8524,61 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.35.0':
     optional: true
 
-  '@oxlint/darwin-arm64@1.43.0':
+  '@oxlint/binding-android-arm-eabi@1.63.0':
     optional: true
 
-  '@oxlint/darwin-x64@1.43.0':
+  '@oxlint/binding-android-arm64@1.63.0':
     optional: true
 
-  '@oxlint/linux-arm64-gnu@1.43.0':
+  '@oxlint/binding-darwin-arm64@1.63.0':
     optional: true
 
-  '@oxlint/linux-arm64-musl@1.43.0':
+  '@oxlint/binding-darwin-x64@1.63.0':
     optional: true
 
-  '@oxlint/linux-x64-gnu@1.43.0':
+  '@oxlint/binding-freebsd-x64@1.63.0':
     optional: true
 
-  '@oxlint/linux-x64-musl@1.43.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
     optional: true
 
-  '@oxlint/win32-arm64@1.43.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
     optional: true
 
-  '@oxlint/win32-x64@1.43.0':
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.63.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.63.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
     optional: true
 
   '@peculiar/asn1-cms@2.6.1':
@@ -8638,32 +8718,11 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.7.25':
+  '@platforma-sdk/block-tools@2.8.2':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.19.4
-      '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.2
-      '@milaboratories/ts-helpers-oclif': 1.1.41
-      '@oclif/core': 4.8.0
-      '@platforma-sdk/blocks-deps-updater': 2.2.0
-      canonicalize: 2.1.0
-      lru-cache: 11.2.4
-      mime-types: 2.1.35
-      tar: 7.5.2
-      undici: 7.16.0
-      yaml: 2.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@platforma-sdk/block-tools@2.8.1':
-    dependencies:
-      '@aws-sdk/client-s3': 3.859.0
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.3.1
+      '@milaboratories/pl-model-backend': 1.3.2
       '@milaboratories/pl-model-common': 1.42.0
       '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3
@@ -8696,12 +8755,12 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.51.0(eslint@9.39.2)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.76.5':
+  '@platforma-sdk/model@1.77.4':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.19.4
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/ptabler-expression-js': 1.2.25
       canonicalize: 2.1.0
       es-toolkit: 1.43.0
@@ -8727,22 +8786,22 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@platforma-sdk/tengo-builder@2.5.29':
+  '@platforma-sdk/tengo-builder@3.0.2':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.2.29
+      '@milaboratories/pl-model-backend': 1.3.2
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.8.0
       winston: 3.19.0
 
-  '@platforma-sdk/test@1.76.6(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.77.7(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))':
     dependencies:
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/pl-client': 3.5.0
-      '@milaboratories/pl-middle-layer': 1.60.0(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-tree': 1.11.0
-      '@platforma-sdk/model': 1.76.5
+      '@milaboratories/pl-client': 3.8.1
+      '@milaboratories/pl-middle-layer': 1.61.3(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-tree': 1.12.1
+      '@platforma-sdk/model': 1.77.4
       '@vitest/coverage-istanbul': 4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))
       vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -8766,12 +8825,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.76.5(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.3.16(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.3.17(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/uikit': 2.14.9(typescript@5.6.3)
-      '@platforma-sdk/model': 1.76.5
+      '@milaboratories/uikit': 2.14.11(typescript@5.6.3)
+      '@platforma-sdk/model': 1.77.4
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -8802,8 +8861,9 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.23.0':
+  '@platforma-sdk/workflow-tengo@5.25.0':
     dependencies:
+      '@milaboratories/pframes-rs-wasip2': 1.1.35
       '@milaboratories/software-pframes-conv': 2.2.9
       '@platforma-open/milaboratories.software-ptabler': 1.16.1
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
@@ -13564,16 +13624,29 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.35.0
       '@oxfmt/binding-win32-x64-msvc': 0.35.0
 
-  oxlint@1.43.0:
+  oxlint-plugin-eslint@1.63.0: {}
+
+  oxlint@1.63.0:
     optionalDependencies:
-      '@oxlint/darwin-arm64': 1.43.0
-      '@oxlint/darwin-x64': 1.43.0
-      '@oxlint/linux-arm64-gnu': 1.43.0
-      '@oxlint/linux-arm64-musl': 1.43.0
-      '@oxlint/linux-x64-gnu': 1.43.0
-      '@oxlint/linux-x64-musl': 1.43.0
-      '@oxlint/win32-arm64': 1.43.0
-      '@oxlint/win32-x64': 1.43.0
+      '@oxlint/binding-android-arm-eabi': 1.63.0
+      '@oxlint/binding-android-arm64': 1.63.0
+      '@oxlint/binding-darwin-arm64': 1.63.0
+      '@oxlint/binding-darwin-x64': 1.63.0
+      '@oxlint/binding-freebsd-x64': 1.63.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.63.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.63.0
+      '@oxlint/binding-linux-arm64-gnu': 1.63.0
+      '@oxlint/binding-linux-arm64-musl': 1.63.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-musl': 1.63.0
+      '@oxlint/binding-linux-s390x-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-musl': 1.63.0
+      '@oxlint/binding-openharmony-arm64': 1.63.0
+      '@oxlint/binding-win32-arm64-msvc': 1.63.0
+      '@oxlint/binding-win32-ia32-msvc': 1.63.0
+      '@oxlint/binding-win32-x64-msvc': 1.63.0
 
   p-filter@2.1.0:
     dependencies:
@@ -13822,7 +13895,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,19 +8,19 @@ packages:
 
 catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
-  '@milaboratories/ts-builder': 1.4.0
+  '@milaboratories/ts-builder': 1.5.0
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 5.23.0
-  '@platforma-sdk/model': 1.76.5
-  '@platforma-sdk/ui-vue': 1.76.5
-  '@platforma-sdk/tengo-builder': 2.5.29
+  '@platforma-sdk/workflow-tengo': 5.25.0
+  '@platforma-sdk/model': 1.77.4
+  '@platforma-sdk/ui-vue': 1.77.4
+  '@platforma-sdk/tengo-builder': 3.0.2
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.8.1
+  '@platforma-sdk/block-tools': 2.8.2
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.76.6
+  '@platforma-sdk/test': 1.77.7
   '@milaboratories/helpers': 1.14.2
-  '@milaboratories/graph-maker': 1.4.1
-  '@milaboratories/multi-sequence-alignment': 1.47.12
+  '@milaboratories/graph-maker': 1.4.3
+  '@milaboratories/multi-sequence-alignment': 1.47.13
   '@milaboratories/strings': 0.1.2
 
   '@milaboratories/software-pframes-conv': 2.2.9

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -307,7 +307,8 @@ def _encode_position_tagged_fixed_length(sequences, seq_len, k, chars):
     )
 
 
-def position_tagged_kmer_vectors(sequences, k=2, alphabet='aminoacid', verbose=True):
+def position_tagged_kmer_vectors(sequences, k=2, alphabet='aminoacid', verbose=True,
+                                 max_len=None):
     """
     Position-tagged k-mer encoding (N-terminus aligned).
 
@@ -323,6 +324,10 @@ def position_tagged_kmer_vectors(sequences, k=2, alphabet='aminoacid', verbose=T
     'N' for nucleotide) at the C-terminus so all sequences reach max length.
     Real residues stay at positions 0..L-1; padded positions sit at the tail.
 
+    `max_len` pins the encoding width across calls. Required when feeding
+    chunks into a pre-fit SVD/UMAP transformer. If omitted, max_len is taken 
+    from the input.
+
     Feature layout: feature_index = position * |chars|^k + kmer_index.
         - Total features: (L_max - k + 1) * |chars|^k
         - Each sequence: (L_max - k + 1) non-zero entries
@@ -331,9 +336,15 @@ def position_tagged_kmer_vectors(sequences, k=2, alphabet='aminoacid', verbose=T
     pad_char = '_' if alphabet == 'aminoacid' else 'N'
 
     n_seqs = len(sequences)
-    max_len = max(map(len, sequences))
+    if max_len is None:
+        max_len = max(map(len, sequences))
     min_len = min(map(len, sequences))
     is_variable = min_len != max_len
+    if max_len < k:
+        raise ValueError(
+            f"Position_tagged_kmer_vectors needs sequences of length >= k={k}, "
+            f"but the longest input sequence has length {max_len}."
+        )
     num_positions = max_len - k + 1
     num_kmers = len(chars) ** k
 
@@ -645,8 +656,9 @@ def parse_args():
                         help='Sequence encoding (default: kmer).\n'
                              '  kmer:     k-mer count vectors (position-agnostic, any length).\n'
                              '  pos-kmer: position-tagged k-mers — each (position, k-mer) pair\n'
-                             '            is a distinct feature. Requires uniform-length\n'
-                             '            sequences. Use --k-mer-size 2 for short peptides.')
+                             '            is a distinct feature. Variable-length sequences are\n'
+                             '            right-padded (N-term aligned) with "_" / "N" up to the\n'
+                             '            longest input. Use --k-mer-size 2 for short peptides.')
     parser.add_argument('--output-dir', default='.',
                         help='Directory for output files (default: current directory).')
     parser.add_argument('--svd-backend', type=str, default='auto',
@@ -790,8 +802,11 @@ def run_gpu_pipeline(args, sequences_all, umap_model):
 
     start_time_kmer = time.time()
     if args.encoding == 'pos-kmer':
+        # Pin pos-kmer width to the global max so feature counts stay consistent.
+        pos_kmer_max_len = max(map(len, sequences_all))
         matrix = position_tagged_kmer_vectors(sequences_all, k=args.k_mer_size,
-                                              alphabet=args.alphabet, verbose=True)
+                                              alphabet=args.alphabet, verbose=True,
+                                              max_len=pos_kmer_max_len)
     else:
         matrix = kmer_count_vectors(sequences_all, k=args.k_mer_size, alphabet=args.alphabet,
                                     n_jobs=args.n_jobs, verbose=True)
@@ -843,6 +858,10 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
     n_all = len(sequences_all)
     num_total_sequences = len(df_valid)
 
+    # Pin pos-kmer width to the global max so fit and chunk-transform calls
+    # produce matrices with the same column count.
+    pos_kmer_max_len = max(map(len, sequences_all)) if args.encoding == 'pos-kmer' else None
+
     # --- Build fit-sample ---
     fit_sample_size = args.max_sequences
     if fit_sample_size > 0 and num_total_sequences > fit_sample_size:
@@ -861,7 +880,8 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
     start_time_kmer = time.time()
     if args.encoding == 'pos-kmer':
         matrix_fit = position_tagged_kmer_vectors(sequences_fit, k=args.k_mer_size,
-                                                  alphabet=args.alphabet, verbose=True)
+                                                  alphabet=args.alphabet, verbose=True,
+                                                  max_len=pos_kmer_max_len)
     else:
         matrix_fit = kmer_count_vectors(sequences_fit, k=args.k_mer_size, alphabet=args.alphabet,
                                         n_jobs=args.n_jobs, verbose=True)
@@ -910,7 +930,8 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
 
         if args.encoding == 'pos-kmer':
             chunk_matrix = position_tagged_kmer_vectors(chunk_seqs, k=args.k_mer_size,
-                                                        alphabet=args.alphabet, verbose=False)
+                                                        alphabet=args.alphabet, verbose=False,
+                                                        max_len=pos_kmer_max_len)
         else:
             chunk_matrix = kmer_count_vectors(chunk_seqs, k=args.k_mer_size,
                                               alphabet=args.alphabet,

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -528,7 +528,7 @@ def compute_svd_embedding(matrix, svd_backend='auto',
                 total_explained = float(np.sum(explained_variance_ratio))
                 if total_explained < 0.01:
                     raise RuntimeError(
-                        f"GPU sparse SVD returned degenerate output "
+                        f"CuPy sparse SVD returned degenerate output "
                         f"(total variance = {total_explained:.4f}). "
                     )
                 use_cupy_sparse_svd = True

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -309,7 +309,7 @@ def _encode_position_tagged_fixed_length(sequences, seq_len, k, chars):
 
 def position_tagged_kmer_vectors(sequences, k=2, alphabet='aminoacid', verbose=True):
     """
-    Position-tagged k-mer encoding.
+    Position-tagged k-mer encoding (N-terminus aligned).
 
     Each k-mer is identified by both its content AND its starting position in
     the sequence: (k-mer 'WT' at position 0) and (k-mer 'WT' at position 3)
@@ -318,25 +318,14 @@ def position_tagged_kmer_vectors(sequences, k=2, alphabet='aminoacid', verbose=T
     k-mers that overlap that position, so similar peptides stay nearby in
     feature space.
 
-    Variable lengths are handled with **dual-end padding** using filler
-    characters ('_' for aminoacid, 'N' for nucleotide):
+    Variable lengths are handled by **right-padding** (N-term alignment):
+    shorter sequences are padded with a filler character ('_' for aminoacid,
+    'N' for nucleotide) at the C-terminus so all sequences reach max length.
+    Real residues stay at positions 0..L-1; padded positions sit at the tail.
 
-        - N-terminal alignment: right-pad with the filler. Position 0 = first
-          residue. Padded positions sit at the C-terminal tail. Captures
-          motifs anchored to the start.
-        - C-terminal alignment: left-pad with the filler. Position L_max - 1 =
-          last residue. Padded positions sit at the N-terminal head. Captures
-          motifs anchored to the end.
-
-    For variable-length input both encodings are computed and horizontally
-    stacked, so motifs that are length-agnostic relative to either terminus
-    appear as features. For uniform-length input the two alignments produce
-    identical matrices, so a single encoding is built.
-
-    Feature layout per encoding: feature_index = position * |chars|^k + kmer_index.
-        - N-term block (and C-term block, when present):
-          (L_max - k + 1) * |chars|^k columns each
-        - Each sequence: (L_max - k + 1) non-zero entries per block
+    Feature layout: feature_index = position * |chars|^k + kmer_index.
+        - Total features: (L_max - k + 1) * |chars|^k
+        - Each sequence: (L_max - k + 1) non-zero entries
     """
     chars = _AMINOACID_CHARS if alphabet == 'aminoacid' else _NUCLEOTIDE_CHARS
     pad_char = '_' if alphabet == 'aminoacid' else 'N'
@@ -349,30 +338,21 @@ def position_tagged_kmer_vectors(sequences, k=2, alphabet='aminoacid', verbose=T
     num_kmers = len(chars) ** k
 
     if verbose:
-        block_count = 2 if is_variable else 1
-        label = "dual-end padded (N-term + C-term)" if is_variable else "uniform-length"
-        print(f"Position-tagged {k}-mer encoding ({label}): {n_seqs} sequences × "
-              f"{num_positions} positions × {num_kmers} k-mers × {block_count} block(s) "
-              f"= {num_positions * num_kmers * block_count} features...")
+        print(f"Position-tagged {k}-mer encoding: {n_seqs} sequences × "
+              f"{num_positions} positions × {num_kmers} k-mers = "
+              f"{num_positions * num_kmers} features...")
         if is_variable:
-            print(f"  Input length range: {min_len} to {max_len}. Padding with '{pad_char}'.")
+            print(f"  Input length range: {min_len} to {max_len}. "
+                  f"Right-padding shorter sequences with '{pad_char}'.")
 
-    if not is_variable:
-        # Uniform input — both padding directions would produce identical
-        # matrices, so a single encoding suffices.
-        matrix = _encode_position_tagged_fixed_length(sequences, max_len, k, chars)
-    else:
-        # Variable input — encode twice and hstack so the SVD/UMAP downstream
-        # can pick up motifs anchored to either terminus.
-        #   ljust → right-pad → real residues at positions 0..L-1 → N-term aligned
-        #   rjust → left-pad  → real residues at positions max_len-L..max_len-1 → C-term aligned
-        right_padded = [s if len(s) == max_len else s.ljust(max_len, pad_char)
-                        for s in sequences]
-        left_padded = [s if len(s) == max_len else s.rjust(max_len, pad_char)
-                       for s in sequences]
-        n_term_matrix = _encode_position_tagged_fixed_length(right_padded, max_len, k, chars)
-        c_term_matrix = _encode_position_tagged_fixed_length(left_padded, max_len, k, chars)
-        matrix = sparse.hstack([n_term_matrix, c_term_matrix], format='csr')
+    # Pad shorter sequences with the filler so reshape works. ljust is a no-op
+    # for already-max-length entries — the comprehension only allocates new
+    # strings where needed.
+    if is_variable:
+        sequences = [s if len(s) == max_len else s.ljust(max_len, pad_char)
+                     for s in sequences]
+
+    matrix = _encode_position_tagged_fixed_length(sequences, max_len, k, chars)
 
     if verbose:
         print(f"Position-tagged k-mer matrix created: {matrix.shape}, "

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -1006,13 +1006,46 @@ def main():
                                      "UMAP analysis skipped due to insufficient sequences.")
         sys.exit(0)
 
-    sequences_all = df_valid[SEQ_COL].str.to_uppercase().to_list()
+    n_sequences_all = len(df_valid)
     keys_all = df_valid[KEY_COL].to_list()
 
+    # Make sure all sequences are in uppercase
+    df_valid_upper = df_valid.with_columns(
+        pl.col(SEQ_COL).str.to_uppercase().alias(SEQ_COL)
+    )
+    # Collapse exact duplicates before fitting (They can cause issues in GPU mode)
+    df_unique = (
+        df_valid_upper.unique(subset=[SEQ_COL], keep='first', maintain_order=True)
+        .with_row_index('_uidx')
+    )
+    sequences_unique = df_unique[SEQ_COL].to_list()
+    n_unique = len(sequences_unique)
+    if n_unique < n_sequences_all:
+        print(f"Deduplicating sequences: {n_sequences_all} valid → {n_unique} unique "
+              f"({n_sequences_all - n_unique} duplicates collapsed for SVD/UMAP).")
+
+    if n_unique < min_required_sequences:
+        print(f"Warning: Not enough unique sequences for UMAP analysis "
+              f"(required {min_required_sequences}, unique {n_unique}) — "
+              f"writing empty output.")
+        create_empty_umap_output(KEY_COL, args.umap_components, output_path)
+        create_empty_skipped_summary(args.output_dir,
+                                     "UMAP analysis skipped due to insufficient unique sequences.")
+        sys.exit(0)
+
     if run_type == 'gpu':
-        umap_embed_all = run_gpu_pipeline(args, sequences_all, umap_model)
+        umap_embed_unique = run_gpu_pipeline(args, sequences_unique, umap_model)
     else:
-        umap_embed_all = run_cpu_pipeline(args, df_valid, sequences_all, umap_model)
+        umap_embed_unique = run_cpu_pipeline(args, df_unique, sequences_unique, umap_model)
+
+    # Broadcast unique-row embeddings back to every valid row
+    index_map = (
+        df_valid_upper.select(SEQ_COL)
+        .join(df_unique.select([SEQ_COL, '_uidx']),
+              on=SEQ_COL, how='left', maintain_order='left')
+        ['_uidx'].to_numpy()
+    )
+    umap_embed_all = umap_embed_unique[index_map]
 
     start_time_save = time.time()
     write_outputs(args, df, df_valid, df_invalid, umap_embed_all, keys_all, n_invalid, output_path)

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -522,6 +522,15 @@ def compute_svd_embedding(matrix, svd_backend='auto',
                 svd_u, svd_s, svd_vt = run_cupy_sparse_svd(matrix_gpu, n_components_max)
                 explained_variance_ratio = compute_explained_variance_cupy(
                     svd_s, matrix_gpu, matrix.shape[0])
+                # Sanity check: cupy_svds silently returns near-zero singular
+                # values when k is too close to min(m, n) (Lanczos loses
+                # orthogonality).
+                total_explained = float(np.sum(explained_variance_ratio))
+                if total_explained < 0.01:
+                    raise RuntimeError(
+                        f"GPU sparse SVD returned degenerate output "
+                        f"(total variance = {total_explained:.4f}). "
+                    )
                 use_cupy_sparse_svd = True
                 print("GPU sparse SVD completed successfully.")
             else:

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -103,6 +103,12 @@ SEQ_COL = 'combined_sequence'
 SPARSE_MEMORY_MULTIPLIER = 3.0
 MEMORY_BUFFER_GB = 2.0
 
+# Alphabet character lists — must stay in sync with the regex in
+# load_and_filter_input() and with the alphabet used by kmer_count_vectors().
+_AMINOACID_CHARS = ['A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L',
+                    'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'Y', 'X', '*', '_']
+_NUCLEOTIDE_CHARS = ['A', 'C', 'G', 'T', 'N']
+
 
 # ============================================================================
 # Live-flushed print
@@ -243,6 +249,134 @@ def kmer_count_vectors(sequences, k=3, alphabet='aminoacid', n_jobs=-1, verbose=
 
     if verbose:
         print(f"Sparse matrix created: {matrix.shape}, {matrix.nnz} non-zero entries")
+    return matrix
+
+
+# ============================================================================
+# Position-tagged k-mer encoding
+# ============================================================================
+
+def _encode_position_tagged_fixed_length(sequences, seq_len, k, chars):
+    """
+    Inner encoder. Assumes every sequence is exactly `seq_len` chars (no
+    padding done here). Builds the (n_seqs, (seq_len - k + 1) * |chars|^k)
+    CSR matrix via the vectorized ASCII-lookup + direct-CSR path.
+    """
+    num_chars = len(chars)
+    n_seqs = len(sequences)
+    num_positions = seq_len - k + 1
+    num_kmers = num_chars ** k
+    num_features = num_positions * num_kmers
+
+    # ASCII byte → alphabet-index lookup table. ord('A') maps to 0, ord('C')
+    # to 1, etc. Unknown chars stay at -1 so they trip the check below.
+    ascii_to_idx = np.full(256, -1, dtype=np.int32)
+    for i, c in enumerate(chars):
+        ascii_to_idx[ord(c)] = i
+
+    # Vectorization trick: concatenate all sequences into one big ASCII blob
+    # (C-implemented), then view as a (n_seqs, seq_len) uint8 array zero-copy.
+    # reshape() guarantees uniform length
+    arr = np.frombuffer(''.join(sequences).encode('ascii'),
+                        dtype=np.uint8).reshape(n_seqs, seq_len)
+    char_idx = ascii_to_idx[arr]  # broadcast lookup, shape (n_seqs, seq_len)
+    if not (char_idx >= 0).all():
+        raise ValueError("position_tagged_kmer_vectors received an unknown "
+                         "character — load_and_filter_input should have dropped it.")
+
+    # Encode each window of k characters as a base-`num_chars` integer:
+    #   kmer_index = sum_{i in [0, k)} char_idx[:, p+i] * num_chars^(k-1-i)
+    # This gives a unique kmer_index per distinct k-mer content.
+    powers = num_chars ** np.arange(k - 1, -1, -1, dtype=np.int64)
+    kmer_at_position = np.zeros((n_seqs, num_positions), dtype=np.int64)
+    for p in range(num_positions):
+        kmer_at_position[:, p] = (char_idx[:, p:p + k] * powers).sum(axis=1)
+
+    # Final column index = position * num_kmers + kmer_index. Position offsets
+    # are added per row in one broadcast. Every row has exactly num_positions
+    # non-zeros in increasing column order, so we can build the CSR directly
+    # with a uniform-stride indptr (no COO → CSR conversion needed).
+    col_offsets = (np.arange(num_positions, dtype=np.int64) * num_kmers).reshape(1, -1)
+    col_indices = (col_offsets + kmer_at_position).ravel().astype(np.int32)
+    indptr = np.arange(0, n_seqs * num_positions + 1, num_positions, dtype=np.int32)
+    data = np.ones(n_seqs * num_positions, dtype=np.int8)
+    return sparse.csr_matrix(
+        (data, col_indices, indptr),
+        shape=(n_seqs, num_features),
+        dtype=np.int8,
+    )
+
+
+def position_tagged_kmer_vectors(sequences, k=2, alphabet='aminoacid', verbose=True):
+    """
+    Position-tagged k-mer encoding.
+
+    Each k-mer is identified by both its content AND its starting position in
+    the sequence: (k-mer 'WT' at position 0) and (k-mer 'WT' at position 3)
+    are distinct features. This combines positional encoding's exactness with
+    k-mer composition's shift-robustness — a 1-aa substitution only flips the
+    k-mers that overlap that position, so similar peptides stay nearby in
+    feature space.
+
+    Variable lengths are handled with **dual-end padding** using filler
+    characters ('_' for aminoacid, 'N' for nucleotide):
+
+        - N-terminal alignment: right-pad with the filler. Position 0 = first
+          residue. Padded positions sit at the C-terminal tail. Captures
+          motifs anchored to the start.
+        - C-terminal alignment: left-pad with the filler. Position L_max - 1 =
+          last residue. Padded positions sit at the N-terminal head. Captures
+          motifs anchored to the end.
+
+    For variable-length input both encodings are computed and horizontally
+    stacked, so motifs that are length-agnostic relative to either terminus
+    appear as features. For uniform-length input the two alignments produce
+    identical matrices, so a single encoding is built.
+
+    Feature layout per encoding: feature_index = position * |chars|^k + kmer_index.
+        - N-term block (and C-term block, when present):
+          (L_max - k + 1) * |chars|^k columns each
+        - Each sequence: (L_max - k + 1) non-zero entries per block
+    """
+    chars = _AMINOACID_CHARS if alphabet == 'aminoacid' else _NUCLEOTIDE_CHARS
+    pad_char = '_' if alphabet == 'aminoacid' else 'N'
+
+    n_seqs = len(sequences)
+    max_len = max(map(len, sequences))
+    min_len = min(map(len, sequences))
+    is_variable = min_len != max_len
+    num_positions = max_len - k + 1
+    num_kmers = len(chars) ** k
+
+    if verbose:
+        block_count = 2 if is_variable else 1
+        label = "dual-end padded (N-term + C-term)" if is_variable else "uniform-length"
+        print(f"Position-tagged {k}-mer encoding ({label}): {n_seqs} sequences × "
+              f"{num_positions} positions × {num_kmers} k-mers × {block_count} block(s) "
+              f"= {num_positions * num_kmers * block_count} features...")
+        if is_variable:
+            print(f"  Input length range: {min_len} to {max_len}. Padding with '{pad_char}'.")
+
+    if not is_variable:
+        # Uniform input — both padding directions would produce identical
+        # matrices, so a single encoding suffices.
+        matrix = _encode_position_tagged_fixed_length(sequences, max_len, k, chars)
+    else:
+        # Variable input — encode twice and hstack so the SVD/UMAP downstream
+        # can pick up motifs anchored to either terminus.
+        #   ljust → right-pad → real residues at positions 0..L-1 → N-term aligned
+        #   rjust → left-pad  → real residues at positions max_len-L..max_len-1 → C-term aligned
+        right_padded = [s if len(s) == max_len else s.ljust(max_len, pad_char)
+                        for s in sequences]
+        left_padded = [s if len(s) == max_len else s.rjust(max_len, pad_char)
+                       for s in sequences]
+        n_term_matrix = _encode_position_tagged_fixed_length(right_padded, max_len, k, chars)
+        c_term_matrix = _encode_position_tagged_fixed_length(left_padded, max_len, k, chars)
+        matrix = sparse.hstack([n_term_matrix, c_term_matrix], format='csr')
+
+    if verbose:
+        print(f"Position-tagged k-mer matrix created: {matrix.shape}, "
+              f"{matrix.nnz} non-zero entries")
     return matrix
 
 
@@ -518,6 +652,12 @@ def parse_args():
                         help='UMAP min_dist (default: 0.5).')
     parser.add_argument('--k-mer-size', type=int, default=None,
                         help='Size of k-mers (default: 3 for aminoacid, 6 for nucleotide).')
+    parser.add_argument('--encoding', choices=['kmer', 'pos-kmer'], default='kmer',
+                        help='Sequence encoding (default: kmer).\n'
+                             '  kmer:     k-mer count vectors (position-agnostic, any length).\n'
+                             '  pos-kmer: position-tagged k-mers — each (position, k-mer) pair\n'
+                             '            is a distinct feature. Requires uniform-length\n'
+                             '            sequences. Use --k-mer-size 2 for short peptides.')
     parser.add_argument('--output-dir', default='.',
                         help='Directory for output files (default: current directory).')
     parser.add_argument('--svd-backend', type=str, default='auto',
@@ -660,9 +800,13 @@ def run_gpu_pipeline(args, sequences_all, umap_model):
     n_all = len(sequences_all)
 
     start_time_kmer = time.time()
-    matrix = kmer_count_vectors(sequences_all, k=args.k_mer_size, alphabet=args.alphabet,
-                                n_jobs=args.n_jobs, verbose=True)
-    print(f"K-mer counting completed in {time.time() - start_time_kmer:.2f} seconds.\n")
+    if args.encoding == 'pos-kmer':
+        matrix = position_tagged_kmer_vectors(sequences_all, k=args.k_mer_size,
+                                              alphabet=args.alphabet, verbose=True)
+    else:
+        matrix = kmer_count_vectors(sequences_all, k=args.k_mer_size, alphabet=args.alphabet,
+                                    n_jobs=args.n_jobs, verbose=True)
+    print(f"Encoding completed in {time.time() - start_time_kmer:.2f} seconds.\n")
 
     start_time_svd = time.time()
     print("Running Truncated SVD...")
@@ -724,11 +868,15 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
     sequences_fit = df_fit[SEQ_COL].str.to_uppercase().to_list()
     num_fit_sequences = len(sequences_fit)
 
-    # --- Phase 1a: k-mer matrix on fit sample ---
+    # --- Phase 1a: encode fit sample ---
     start_time_kmer = time.time()
-    matrix_fit = kmer_count_vectors(sequences_fit, k=args.k_mer_size, alphabet=args.alphabet,
-                                    n_jobs=args.n_jobs, verbose=True)
-    print(f"K-mer counting completed in {time.time() - start_time_kmer:.2f} seconds.\n")
+    if args.encoding == 'pos-kmer':
+        matrix_fit = position_tagged_kmer_vectors(sequences_fit, k=args.k_mer_size,
+                                                  alphabet=args.alphabet, verbose=True)
+    else:
+        matrix_fit = kmer_count_vectors(sequences_fit, k=args.k_mer_size, alphabet=args.alphabet,
+                                        n_jobs=args.n_jobs, verbose=True)
+    print(f"Encoding completed in {time.time() - start_time_kmer:.2f} seconds.\n")
 
     # --- Phase 1b: fit SVD ---
     start_time_svd = time.time()
@@ -771,8 +919,13 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
         chunk_end = min(chunk_start + TRANSFORM_CHUNK_SIZE, n_all)
         chunk_seqs = sequences_all[chunk_start:chunk_end]
 
-        chunk_matrix = kmer_count_vectors(chunk_seqs, k=args.k_mer_size, alphabet=args.alphabet,
-                                          n_jobs=args.n_jobs, verbose=False)
+        if args.encoding == 'pos-kmer':
+            chunk_matrix = position_tagged_kmer_vectors(chunk_seqs, k=args.k_mer_size,
+                                                        alphabet=args.alphabet, verbose=False)
+        else:
+            chunk_matrix = kmer_count_vectors(chunk_seqs, k=args.k_mer_size,
+                                              alphabet=args.alphabet,
+                                              n_jobs=args.n_jobs, verbose=False)
         chunk_svd = svd_transformer.transform(chunk_matrix)
         chunk_umap = umap_model.transform(chunk_svd)
         all_coords.append(chunk_umap)

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -1,31 +1,30 @@
-import type { PColumnPredicate, PColumnSpec } from '@platforma-sdk/model';
+import type { PColumnPredicate } from '@platforma-sdk/model';
 import { type PTableColumnSpec, Annotation, Domain, PAxisName, readAnnotationJson, readDomain } from '@platforma-sdk/model';
 
 export const isSequenceColumn: PColumnPredicate = ({ spec }) => {
-  const isBulkSequence = (spec: PColumnSpec) =>
-    spec.name !== 'pl7.app/vdj/sequenceLength'
-    && spec.name !== 'pl7.app/vdj/sequence/annotation'
-    && readDomain(spec, Domain.Alphabet) === 'aminoacid'
-    // Peptide specific
-    && spec.name !== 'pl7.app/sequenceLength'
-    // Reject cluster-centroid sequences
-    && spec.axesSpec[0]?.name !== 'pl7.app/clusterId';
+  // Length / annotation columns are not sequence data.
+  if (
+    spec.name === 'pl7.app/vdj/sequenceLength'
+    || spec.name === 'pl7.app/sequenceLength'
+    || spec.name === 'pl7.app/vdj/sequence/annotation'
+  ) return false;
+  // Reject cluster-centroid sequences (their axis is clusterId, not the
+  // input's clonotype/variant axis).
+  if (spec.axesSpec[0]?.name === 'pl7.app/clusterId') return false;
+  // Only amino-acid sequences belong in MSA.
+  if (readDomain(spec, Domain.Alphabet) !== 'aminoacid') return false;
+  // Single-cell sequences: reject non-primary chains (e.g. light), but keep
+  // chain-less constructs like scFv where the domain field is absent entirely.
+  if (spec.axesSpec[0]?.name === PAxisName.VDJ.ScClonotypeKey) {
+    const chainIndex = readDomain(spec, Domain.VDJ.ScClonotypeChain.Index);
+    if (chainIndex !== undefined && chainIndex !== 'primary') return false;
+  }
 
-  const isSingleCellSequence = (spec: PColumnSpec) =>
-    spec.name !== 'pl7.app/vdj/sequenceLength'
-    && spec.name !== 'pl7.app/vdj/sequence/annotation'
-    && readDomain(spec, Domain.VDJ.ScClonotypeChain.Index) === 'primary'
-    && readDomain(spec, Domain.Alphabet) === 'aminoacid'
-    && spec.axesSpec[0].name === PAxisName.VDJ.ScClonotypeKey;
-
-  return (isBulkSequence(spec) || isSingleCellSequence(spec))
-    && {
-      // VDJ uses 'pl7.app/vdj/isAssemblingFeature'; peptide-extraction emits
-      // the modality-neutral 'pl7.app/isAssemblingFeature' (no `vdj/` prefix).
-      default: readAnnotationJson(spec, Annotation.VDJ.IsAssemblingFeature)
-        ?? readAnnotationJson(spec, 'pl7.app/isAssemblingFeature' as never)
-        ?? false,
-    };
+  // Default-select the assembling-feature sequence.
+  const isAssemblingFeature
+    = readAnnotationJson(spec, Annotation.VDJ.IsAssemblingFeature)
+      ?? spec.annotations?.['pl7.app/isAssemblingFeature'] === 'true';
+  return { default: isAssemblingFeature };
 };
 
 export function defaultFilters(tSpec: PTableColumnSpec): (unknown | undefined) {

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -23,6 +23,14 @@ wf.body(func(args) {
 		bundleBuilder.addSingle(ref)
 	}
 
+	// Peptide-only: pull the per-peptide sequence length column.
+	bundleBuilder.addMulti(
+		{
+			axes: [{ anchor: "main", idx: 1 }],
+			name: "pl7.app/sequenceLength",
+			domain: { "pl7.app/feature": "peptide" }
+		}, "peptideSequenceLength")
+
 	columns := bundleBuilder.build()
 
 	// Delegate to the inner template. Its body runs as soon as upstream specs are

--- a/workflow/src/min-peptide-length.tpl.tengo
+++ b/workflow/src/min-peptide-length.tpl.tengo
@@ -1,0 +1,27 @@
+self := import("@platforma-sdk/workflow-tengo:tpl")
+pt   := import("@platforma-sdk/workflow-tengo:pt")
+
+self.validateInputs({
+	"__options__,closed": "",
+	spec: "any",
+	data: "any"
+})
+
+self.defineOutputs("minLength")
+
+self.body(func(inputs) {
+	// Reconstruct the column map shape pt expects.
+	lenColumn := { spec: inputs.spec, data: inputs.data }
+
+	// Whole-frame aggregation: emits a single-row TSV with the min value.
+	ptWf := pt.workflow()
+	ptWf.frame(pt.p.column("len", lenColumn)).
+		select(pt.col("len").min().alias("min_len")).
+		saveContent("min_len.ndjson")
+
+	ptResult := ptWf.run()
+
+	return {
+		minLength: ptResult.getFileContent("min_len.ndjson")
+	}
+})

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -15,6 +15,7 @@ xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 umapConv := import(":pf-umap-conv")
 
 umapCalculationTpl := assets.importTemplate(":umap-calculation")
+minPeptideLengthTpl := assets.importTemplate(":min-peptide-length")
 
 // Await only column specs — NOT data. This is what enables early spec export.
 self.awaitState("columns", "PColumnBundle")
@@ -39,6 +40,22 @@ self.body(func(inputs) {
 	// Spec is plain JSON, available now (PColumnBundle await covered specs).
 	datasetSpec := columns.getSpec(inputAnchor)
 
+	// compute the shortest peptide length
+	isPeptide := datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
+	minPeptideLength := undefined
+	if isPeptide {
+		peptideLenCols := columns.getColumns("peptideSequenceLength")
+		if len(peptideLenCols) > 0 {
+			minLenResult := render.create(minPeptideLengthTpl, {
+				spec: peptideLenCols[0].spec,
+				data: peptideLenCols[0].data
+			})
+			minPeptideLength = minLenResult.output("minLength")
+		} else {
+			ll.panic("Peptide input is missing required pl7.app/sequenceLength column")
+		}
+	}
+
 	// Build input TSV with clonotype id and selected sequence columns.
 	// Column data is a deferred reference here — the TSV builder consumes it lazily.
 	umapTable := pframes.tsvFileBuilder()
@@ -57,7 +74,9 @@ self.body(func(inputs) {
 		umapTable: umapTable,
 		umap_neighbors: umap_neighbors,
 		umap_min_dist: umap_min_dist,
-		alphabet: alphabet
+		alphabet: alphabet,
+		isPeptide: isPeptide,
+		minPeptideLength: minPeptideLength
 	}, {
 		metaInputs: {
 			mem: mem,

--- a/workflow/src/umap-calculation.tpl.tengo
+++ b/workflow/src/umap-calculation.tpl.tengo
@@ -1,8 +1,9 @@
-//tengo:hash_override 16D7E7CE-5B0D-4D2C-A8BF-6909B926FA9C
+//tengo:hash_override 16D7E7CE-5B0D-4D2C-A8BF-6909B926FA9D
 
 self := import("@platforma-sdk/workflow-tengo:tpl")
 exec := import("@platforma-sdk/workflow-tengo:exec")
 assets := import("@platforma-sdk/workflow-tengo:assets")
+json := import("json")
 
 self.defineOutputs("umapTsVFile", "umapOutput")
 
@@ -20,6 +21,18 @@ self.body(func(args) {
     if alphabet == "nucleotide" {
         kmerSize = 6
     }
+    encoding := "kmer"
+
+    // Short-peptide override: when the input is peptide-mode AND the shortest
+    // peptide is below 10 aa
+    isPeptide := is_undefined(args.isPeptide) ? false : args.isPeptide
+    if isPeptide && !is_undefined(args.minPeptideLength) {
+        minLen := int(json.decode(string(args.minPeptideLength.getData())).min_len)
+        if minLen < 10 {
+            kmerSize = 2
+            encoding = "pos-kmer"
+        }
+    }
 
     // UMAP software execution
     // Note: --seq-col-start "sequence" will match all columns starting with "sequence"
@@ -36,6 +49,7 @@ self.body(func(args) {
         arg("--umap-min-dist").arg(string(umap_min_dist)).
         arg("--alphabet").arg(alphabet).
         arg("--k-mer-size").arg(string(kmerSize)).
+        arg("--encoding").arg(encoding).
         arg("--n-jobs").arg(string(cpu)).
         saveFile("umap.tsv").
         saveFile("skipped_clonotypes_summary.txt").


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a positional k-mer (`pos-kmer`) encoder for short peptides, automatically switching to it when the minimum peptide length in a dataset is below 10 aa. The workflow gains a new `min-peptide-length` template to compute that minimum, and the Python UMAP tool gains a `--encoding` flag and the `position_tagged_kmer_vectors` function that handles variable-length sequences via dual-end padding.

- **New encoding**: `_encode_position_tagged_fixed_length` and `position_tagged_kmer_vectors` build a CSR matrix where each (position, k-mer) pair is a distinct feature, with `k=2` replacing the default `k=3` for short peptides.
- **Workflow integration**: `process.tpl.tengo` detects peptide mode, invokes the new `min-peptide-length` template to retrieve the shortest sequence length, and passes it to `umap-calculation.tpl.tengo`, which sets encoding and k-mer size accordingly.
- **Publishing change**: `--unstable` removed from the `prepublishOnly` script, promoting future releases to the stable channel.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The CPU pipeline will crash at runtime for any variable-length peptide dataset using the new pos-kmer encoding, because each chunk produces a feature matrix sized to its local max-length rather than the global max-length used during SVD fitting.

The chunk-vs-fit feature dimension mismatch in run_cpu_pipeline is a current defect on the new code path. Because pos-kmer is activated automatically whenever the shortest peptide is under 10 aa, any user without GPU acceleration running a mixed-length peptide dataset will hit this crash. The GPU path is unaffected.

software/umap/src/main.py — specifically run_cpu_pipeline's chunked transform loop and position_tagged_kmer_vectors.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/umap/src/main.py | Adds position-tagged k-mer encoding for short peptides; contains a chunk/fit feature-dimension mismatch bug in run_cpu_pipeline, and a potential crash when sequences are shorter than k. |
| workflow/src/umap-calculation.tpl.tengo | Reads min peptide length from NDJSON and switches to pos-kmer/k=2 when minLen < 10; hash updated; logic looks correct. |
| workflow/src/min-peptide-length.tpl.tengo | New template that computes the per-dataset minimum peptide length using pt aggregation; straightforward and looks correct. |
| workflow/src/process.tpl.tengo | Detects peptide mode via axis spec, fetches sequenceLength column, invokes min-peptide-length template, and passes results downstream; logic consistent with the rest of the PR. |
| workflow/src/main.tpl.tengo | Adds addMulti call to pull pl7.app/sequenceLength peptide column into the bundle; minimal and correct. |
| block/package.json | Removes --unstable flag from prepublishOnly, promoting publish to stable channel; presumably intentional for this release. |
| .changeset/lemon-dragons-battle.md | Changeset entry for the minor version bump covering positional k-mer encoder feature. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant M as main.tpl.tengo
    participant P as process.tpl.tengo
    participant ML as min-peptide-length.tpl.tengo
    participant U as umap-calculation.tpl.tengo
    participant PY as main.py (Python)

    M->>P: columns (with peptideSequenceLength)
    P->>P: "isPeptide = axesSpec[1].name == variantKey"
    alt isPeptide
        P->>ML: spec + data (sequenceLength column)
        ML->>ML: pt aggregation min(len) → min_len.ndjson
        ML-->>P: minLength (NDJSON file content)
    end
    P->>U: umapTable, alphabet, isPeptide, minPeptideLength
    U->>U: json.decode(minPeptideLength) → minLen
    alt "minLen < 10"
        U->>U: "kmerSize=2, encoding=pos-kmer"
    else
        U->>U: "kmerSize=3 (or 6), encoding=kmer"
    end
    U->>PY: --encoding pos-kmer --k-mer-size 2
    PY->>PY: "position_tagged_kmer_vectors(sequences, k=2)"
    PY-->>U: umap.tsv
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
software/umap/src/main.py:922-929
**Chunk feature-dimension mismatch with pos-kmer encoding**

`position_tagged_kmer_vectors` derives its feature count from `max(len(s) for s in sequences)` — a local maximum within the batch passed to it. During Phase 2, each `chunk_seqs` slice is encoded independently, so chunks whose local `max_len` differs from the fit sample's `max_len` will produce a matrix with a different number of columns than the SVD transformer expects. `svd_transformer.transform(chunk_matrix)` then crashes with a shape mismatch (`X @ components_.T` requires matching column count). The same `is_variable` flag can also flip between the fit sample (possibly all same-length → 1 block) and a chunk (mixed lengths → 2 blocks), doubling the feature count. A per-sequence-length normalisation step or passing the global `max_len` to every invocation of the function is needed to fix this.

### Issue 2 of 3
software/umap/src/main.py:658-660
The `--encoding` help text says "Requires uniform-length sequences" but the implementation actively handles variable-length inputs via dual-end padding. This is misleading for anyone choosing an encoding manually and may discourage use of `pos-kmer` on mixed-length datasets where it still works.

```suggestion
                             '  pos-kmer: position-tagged k-mers — each (position, k-mer) pair\n'
                             '            is a distinct feature. Handles variable-length\n'
                             '            sequences via dual-end padding. Use --k-mer-size 2 for short peptides.')
```

### Issue 3 of 3
software/umap/src/main.py:259-307
**Sequences shorter than `k` cause a zero-step `np.arange` error**

If any sequence has `len(seq) < k` (e.g. a single-residue peptide with `k=2`), `num_positions = seq_len - k + 1` evaluates to `0`, and `np.arange(0, n_seqs * 0 + 1, 0)` raises `ValueError: cannot create a step-less range`. The `load_and_filter_input` filter only removes empty sequences, not ones shorter than `k`. Although single-residue peptides are rare, adding a pre-check — or at minimum an early-return path when `num_positions <= 0` — would prevent a cryptic crash.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/clonotype-space/commit/dd55c8f12891b98dc867000c9f058a4d9661b328) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33544604)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->