### PR TITLE
[canary] check-coverage@v4-beta — catalog bump must pass (do not merge)

### DIFF
--- a/.github/workflows/zz-canary-check-coverage.yaml
+++ b/.github/workflows/zz-canary-check-coverage.yaml
@@ -1,0 +1,55 @@
+# TEMPORARY canary — DELETE before merge.
+#
+# Runs milaboratory/github-ci's changeset check-coverage action pinned at
+# @v4-beta (the fixed version) directly against this PR. The normal build
+# chain can't exercise it: build.yaml calls node-simple-pnpm.yaml@v4, whose
+# internal action refs are all pinned at @v4 (the old, over-flagging version).
+# This job bypasses that to prove the @v4-beta behaviour before promoting
+# v4-beta -> v4.
+#
+# Self-contained on purpose: it mirrors the real `changeset coverage`
+# job's setup (checkout full history, prepare-pnpm, install, run the action)
+# but installs with --no-frozen-lockfile so a catalog bump needs no committed
+# lockfile churn.
+name: canary check-coverage @v4-beta
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  canary-check-coverage:
+    name: canary check-coverage @v4-beta
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - name: Ensure base ref is present
+        run: git fetch origin main:refs/remotes/origin/main
+
+      - name: Prepare pnpm + node
+        uses: milaboratory/github-ci/actions/node/prepare-pnpm@v4
+        env:
+          NPMJS_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+        with:
+          node-version: '20.x'
+          pnpm-version: '9.14.4'
+          npmrc-config: |
+            {
+              "registries": {
+                "https://registry.npmjs.org/": {
+                  "scopes": ["milaboratories", "platforma-sdk", "platforma-open"],
+                  "tokenVar": "NPMJS_TOKEN"
+                }
+              }
+            }
+
+      - name: Install
+        run: pnpm install --no-frozen-lockfile --prefer-offline
+
+      - name: Check changeset coverage (@v4-beta)
+        uses: milaboratory/github-ci/actions/changeset/check-coverage@v4-beta
+        with:
+          base-branch: main

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.5.0
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 6.3.2
+  '@platforma-sdk/workflow-tengo': 6.4.0
   '@platforma-sdk/model': 1.78.9
   '@platforma-sdk/ui-vue': 1.78.11
   '@platforma-sdk/tengo-builder': 4.0.7


### PR DESCRIPTION
## Purpose — temporary canary, do not merge

Validates the `check-coverage` fix (milaboratory/github-ci#183, on `v4-beta`) against a real block before promoting `v4-beta → v4`.

## What this PR does

Bumps the `@platforma-sdk/workflow-tengo` catalog entry `6.3.2 → 6.4.0`. That package is a runtime `catalog:` dependency of `.workflow`. The PR touches **no package source** and adds **no changeset** — the exact shape that the old check failed in #95 (it flagged the untouched `.workflow`).

## How to read the result

The added `zz-canary check-coverage @v4-beta` job runs `check-coverage@v4-beta` directly (the normal build chain can't — `node-simple-pnpm.yaml@v4` pins every action at `@v4`).

- **`canary check-coverage @v4-beta` → must be GREEN.** A dependency bump never requires a changeset; the fixed action ignores it.
- **`changeset coverage (diagnostic)` (the normal `@v4` job) → expected RED**, flagging `.workflow`. That contrast is the proof: same PR, old action fails, fixed action passes.

The `build`/release jobs may be red (the catalog bump has no committed lockfile update, and the real chain installs `--frozen-lockfile`). Irrelevant here — only the canary job matters.

Close without merging once observed.