### PR TITLE
Julenmendieta/MILAB-6357_supportEmbeddings

### DIFF
--- a/.changeset/lemon-coats-lead.md
+++ b/.changeset/lemon-coats-lead.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.clonotype-space.umap": minor
+"@platforma-open/milaboratories.clonotype-space.workflow": minor
+"@platforma-open/milaboratories.clonotype-space.model": minor
+"@platforma-open/milaboratories.clonotype-space.ui": minor
+---
+
+Adapt block to embeddings

--- a/model/src/dataModel.ts
+++ b/model/src/dataModel.ts
@@ -21,12 +21,16 @@ export const blockDataModel = new DataModelBuilder()
   .upgradeLegacy<LegacyBlockArgs, LegacyBlockUiState>(({ args, uiState }) => ({
     customBlockLabel: args?.customBlockLabel ?? '',
     inputAnchor: args?.inputAnchor,
+    // Existing projects load in sequence mode (embedding mode is opt-in).
+    inputMode: 'sequence-features',
     sequencesRef: args?.sequencesRef ?? [],
     // No V1 source: the previous build derived labels live via a UI hairpin.
     // Seeded empty here; the UI's auto-select watcher reseeds them from the
     // current options on load (no user interaction required).
     sequenceLabels: [],
     sequenceType: args?.sequenceType ?? 'aminoacid',
+    embeddingRef: undefined,
+    selectedEmbeddingLabel: '',
     umap_neighbors: args?.umap_neighbors ?? 15,
     umap_min_dist: args?.umap_min_dist ?? 0.5,
     cpu: args?.cpu ?? 8,
@@ -37,9 +41,12 @@ export const blockDataModel = new DataModelBuilder()
   .init(() => ({
     customBlockLabel: '',
     inputAnchor: undefined,
+    inputMode: 'sequence-features', // embedding mode is opt-in
     sequencesRef: [],
     sequenceLabels: [],
     sequenceType: 'aminoacid',
+    embeddingRef: undefined,
+    selectedEmbeddingLabel: '',
     umap_neighbors: 15,
     umap_min_dist: 0.5,
     cpu: 8,

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,3 +1,4 @@
+import strings from '@milaboratories/strings';
 import type {
   DataInfo,
   InferOutputsType,
@@ -11,8 +12,8 @@ import type {
 import {
   BlockModelV3,
   createPFrameForGraphs,
+  isPColumnSpec,
 } from '@platforma-sdk/model';
-import strings from '@milaboratories/strings';
 import { blockDataModel } from './dataModel';
 import { getDefaultBlockLabel } from './label';
 import type { BlockArgs, BlockData } from './types';
@@ -44,7 +45,16 @@ const inputAnchorSpecs = [
 ];
 
 function computeDefaultLabel(data: BlockData): string {
+  if (data.inputMode === 'embedding') {
+    return getDefaultBlockLabel({
+      inputMode: 'embedding',
+      embeddingLabel: data.selectedEmbeddingLabel ?? '',
+      umap_neighbors: data.umap_neighbors,
+      umap_min_dist: data.umap_min_dist,
+    });
+  }
   return getDefaultBlockLabel({
+    inputMode: 'sequence-features',
     sequenceLabels: data.sequenceLabels,
     umap_neighbors: data.umap_neighbors,
     umap_min_dist: data.umap_min_dist,
@@ -72,23 +82,33 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
     if (data.inputAnchor === undefined) throw new Error('Input dataset is required');
-    if (data.sequencesRef.length === 0) throw new Error('At least one sequence column is required');
     if (data.umap_neighbors === undefined) throw new Error('UMAP neighbors is required');
     if (data.umap_min_dist === undefined) throw new Error('UMAP min distance is required');
     if (data.cpu === undefined) throw new Error('CPU is required');
     if (data.mem === undefined) throw new Error('Memory is required');
 
-    return {
+    // Shared by both modes. The lambda branches on inputMode and returns ONLY the active mode's
+    // fields, so a stale off-mode value can't affect the run.
+    const shared = {
       defaultBlockLabel: computeDefaultLabel(data),
       customBlockLabel: data.customBlockLabel,
       inputAnchor: data.inputAnchor,
-      sequencesRef: data.sequencesRef,
-      sequenceType: data.sequenceType,
+      inputMode: data.inputMode,
       umap_neighbors: data.umap_neighbors,
       umap_min_dist: data.umap_min_dist,
       cpu: data.cpu,
       mem: data.mem,
     };
+
+    if (data.inputMode === 'embedding') {
+      if (!data.embeddingRef)
+        throw new Error('Connect a Sequence Embeddings output and pick an embedding column to project by embedding');
+      // The embedding model is read from the column spec in the workflow, not snapshotted here (R10).
+      return { ...shared, embeddingRef: data.embeddingRef };
+    }
+
+    if (data.sequencesRef.length === 0) throw new Error('At least one sequence column is required');
+    return { ...shared, sequencesRef: data.sequencesRef, sequenceType: data.sequenceType };
   })
 
   .output('inputOptions', (ctx) =>
@@ -189,6 +209,37 @@ export const platforma = BlockModelV3.create(blockDataModel)
       if (a.isMain && !b.isMain) return -1;
       if (b.isMain && !a.isMain) return 1;
       return 0;
+    });
+  })
+
+  .output('embeddingOptions', (ctx) => {
+    const ref = ctx.data.inputAnchor;
+    if (ref === undefined) return undefined;
+    // PlRef-based options (NOT getCanonicalOptions): the embedding's producer must be wired as an
+    // upstream via wf.resolve(PlRef), so the picker binds a PlRef.
+    const datasetSpec = ctx.resultPool.getPColumnSpecByRef(ref);
+    const cloneAxis = datasetSpec?.axesSpec?.[1];
+    if (cloneAxis === undefined) return undefined;
+    const sameClonotypeAxis = (embAxis?: { name?: string; domain?: Record<string, string> }) => {
+      if (embAxis === undefined || embAxis.name !== cloneAxis.name) return false;
+      const datasetDomain = cloneAxis.domain ?? {};
+      const embDomain = embAxis.domain ?? {};
+      return Object.keys(datasetDomain).every((k) => embDomain[k] === datasetDomain[k]);
+    };
+    const options = ctx.resultPool.getOptions(
+      (spec) => isPColumnSpec(spec)
+        && spec.name === 'pl7.app/embedding'
+        && sameClonotypeAxis(spec.axesSpec?.[0]),
+      { label: { includeNativeLabel: true } },
+    );
+    return options.map((o) => {
+      const spec = ctx.resultPool.getPColumnSpecByRef(o.ref);
+      return {
+        ref: o.ref,
+        label: o.label,
+        feature: spec?.domain?.['pl7.app/feature'],
+        chain: spec?.domain?.['pl7.app/vdj/scClonotypeChain'],
+      };
     });
   })
 

--- a/model/src/label.ts
+++ b/model/src/label.ts
@@ -1,10 +1,24 @@
-export function getDefaultBlockLabel(data: {
-  sequenceLabels: string[];
-  umap_neighbors: number;
-  umap_min_dist: number;
-}) {
+// Single source of truth for the auto-subtitle, one variant per input mode.
+export function getDefaultBlockLabel(
+  data:
+    | {
+      inputMode: 'sequence-features';
+      sequenceLabels: string[];
+      umap_neighbors: number;
+      umap_min_dist: number;
+    }
+    | {
+      inputMode: 'embedding';
+      embeddingLabel: string;
+      umap_neighbors: number;
+      umap_min_dist: number;
+    },
+) {
   const parts: string[] = [];
-  if (data.sequenceLabels.length > 0) {
+  if (data.inputMode === 'embedding') {
+    parts.push(data.embeddingLabel || 'Embedding');
+    parts.push('UMAP');
+  } else if (data.sequenceLabels.length > 0) {
     parts.push(data.sequenceLabels.join('+'));
   }
   parts.push(`nbrs: ${data.umap_neighbors}`);

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -7,10 +7,20 @@ import type {
 
 export type SequenceType = 'aminoacid' | 'nucleotide';
 
+/**
+ * UMAP feature source.
+ */
+export type InputMode = 'sequence-features' | 'embedding';
+
 /** Unified V3 data: persisted state, shaped on the UI's terms. */
 export type BlockData = {
   customBlockLabel: string;
   inputAnchor?: PlRef;
+  /**
+   * UMAP feature source. Defaulted to `sequence-features` in `init()` and the
+   * `upgradeLegacy` path so existing projects load in sequence mode.
+   */
+  inputMode: InputMode;
   sequencesRef: SUniversalPColumnId[];
   /**
    * Snapshot of human-readable labels for `sequencesRef`, written by the UI in
@@ -19,6 +29,15 @@ export type BlockData = {
    */
   sequenceLabels: string[];
   sequenceType: SequenceType;
+  /**
+   * Embedding column.
+   */
+  embeddingRef?: PlRef;
+  /**
+   * Snapshot of the picked embedding column's native label, written by the UI on
+   * the selection gesture.
+   */
+  selectedEmbeddingLabel: string;
   umap_neighbors: number;
   umap_min_dist: number;
   cpu: number;
@@ -27,13 +46,22 @@ export type BlockData = {
   alignmentModel: PlMultiSequenceAlignmentModel;
 };
 
-/** Projected args consumed by the workflow. */
+/**
+ * Projected args consumed by the workflow. The `.args` lambda branches on
+ * `inputMode` and returns only the active mode's fields plus the shared ones
+ * (V3 conditional suppression): `sequencesRef`/`sequenceType` are present
+ * only in sequence mode, `embeddingRef` only in embedding mode.
+ */
 export type BlockArgs = {
   defaultBlockLabel: string;
   customBlockLabel: string;
   inputAnchor: PlRef;
-  sequencesRef: SUniversalPColumnId[];
-  sequenceType: SequenceType;
+  inputMode: InputMode;
+  // Sequence-features mode (omitted in embedding mode).
+  sequencesRef?: SUniversalPColumnId[];
+  sequenceType?: SequenceType;
+  // Embedding mode (omitted in sequence mode).
+  embeddingRef?: PlRef;
   umap_neighbors: number;
   umap_min_dist: number;
   cpu: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: 0.1.2
       version: 0.1.2
     '@milaboratories/ts-builder':
-      specifier: 1.5.0
-      version: 1.5.0
+      specifier: 1.5.2
+      version: 1.5.2
     '@milaboratories/ts-configs':
       specifier: 1.2.3
       version: 1.2.3
@@ -31,29 +31,29 @@ catalogs:
       specifier: 1.7.9
       version: 1.7.9
     '@platforma-sdk/block-tools':
-      specifier: 2.10.9
-      version: 2.10.9
+      specifier: 2.11.0
+      version: 2.11.0
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.78.9
-      version: 1.78.9
+      specifier: 1.79.6
+      version: 1.79.6
     '@platforma-sdk/package-builder':
       specifier: 3.13.0
       version: 3.13.0
     '@platforma-sdk/tengo-builder':
-      specifier: 4.0.7
-      version: 4.0.7
+      specifier: 4.0.8
+      version: 4.0.8
     '@platforma-sdk/test':
-      specifier: 1.78.10
-      version: 1.78.10
+      specifier: 1.79.13
+      version: 1.79.13
     '@platforma-sdk/ui-vue':
-      specifier: 1.78.11
-      version: 1.78.11
+      specifier: 1.79.11
+      version: 1.79.11
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.3.2
-      version: 6.3.2
+      specifier: 6.6.3
+      version: 6.6.3
     '@types/node':
       specifier: ^24.5.2
       version: 24.10.4
@@ -91,7 +91,7 @@ importers:
         version: 2.29.8(@types/node@25.0.3)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.10.9
+        version: 2.11.0(@types/node@25.0.3)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -115,33 +115,33 @@ importers:
         version: link:../workflow
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.78.9
+        version: 1.79.6
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.10.9
+        version: 2.11.0(@types/node@25.0.3)
 
   model:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.6(@milaboratories/pl-model-common@1.46.0)(@platforma-sdk/model@1.78.9)(@platforma-sdk/ui-vue@1.78.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.78.9
+        version: 1.79.6
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.5.0(@types/node@24.10.4)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.5.2(@types/node@24.10.4)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.10.9
+        version: 2.11.0(@types/node@24.10.4)
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.15.0)(typescript-eslint@8.51.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
@@ -175,7 +175,7 @@ importers:
     devDependencies:
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.78.10(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+        version: 1.79.13(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
@@ -187,13 +187,13 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.6(@milaboratories/pl-model-common@1.46.0)(@platforma-sdk/model@1.78.9)(@platforma-sdk/ui-vue@1.78.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.16(@milaboratories/pl-model-common@1.46.0)(@platforma-sdk/model@1.78.9)(@platforma-sdk/ui-vue@1.78.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.16(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -202,10 +202,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.78.9
+        version: 1.79.6
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.78.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@vueuse/core':
         specifier: 'catalog:'
         version: 13.9.0(vue@3.5.24(typescript@5.6.3))
@@ -215,7 +215,7 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.5.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.5.2(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
         version: 1.2.3
@@ -242,11 +242,11 @@ importers:
         version: link:../software/umap
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.3.2
+        version: 6.6.3
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 4.0.7
+        version: 4.0.8
 
 packages:
 
@@ -1065,8 +1065,133 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -1178,8 +1303,8 @@ packages:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
 
-  '@milaboratories/pf-driver@1.7.4':
-    resolution: {integrity: sha512-YhIHxBuHit7sSoh2tsQoU3EkkLr3eHNYVrJABfbKc71aeCVHem6kvRSnGwRPXNiGN7WnaEEQzAuExRP4/xG2RA==}
+  '@milaboratories/pf-driver@1.7.11':
+    resolution: {integrity: sha512-p9dANGg5VfSMIM3ysEUjQ86IfoPRqnww0kmhuaPI4h98kb+7CGbUz/XM0DFq4jALua1fTC3TxuMIY8JV8SJT8Q==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pf-plots@1.4.4':
@@ -1188,46 +1313,46 @@ packages:
       '@milaboratories/pl-model-common': 1.39.0
       '@platforma-sdk/model': 1.73.3
 
-  '@milaboratories/pf-spec-driver@1.4.6':
-    resolution: {integrity: sha512-KxFnWsRTMwI3S4OkO7LM6gsXsKqFT49g2cRn0wC05ykQ98jsHPpnfuYkDoJVRmNxyChejANDNzcR0rljGwLGEQ==}
+  '@milaboratories/pf-spec-driver@1.4.13':
+    resolution: {integrity: sha512-1ylUmz0AgPSRE5DfcNxydv4JVaj4hwCQ1VCW+BWElSIRvlL9IaS4FWSckechQVDb7El9vSTRkrJE5IPx9T2z7A==}
 
-  '@milaboratories/pframes-rs-node@1.1.42':
-    resolution: {integrity: sha512-Mzw2VjqeoJPoB1F8IKngVysJJcqeLvT6K+RkR6RH8SAFAiVPUvlhOdvATwZCYOMSgs8r3tQouI/qVeKdGYSoIQ==}
+  '@milaboratories/pframes-rs-node@1.1.50':
+    resolution: {integrity: sha512-XshCE3Z9+tAKszlWCSDYJnpYRTIsag8v3YcjPmP6//W3dXDDrqi6gBqaGI0u58V9C3PLCjP3zC85vmtI5L26BQ==}
 
-  '@milaboratories/pframes-rs-serv@1.1.42':
-    resolution: {integrity: sha512-it0Hx317mTod4o6+sujGR5mPwo3pseptX1ghSxJgaWHM18ZgLy1+VARKbp8LeoOoWrUqjhQFXcAKo4R8PTSQog==}
+  '@milaboratories/pframes-rs-serv@1.1.50':
+    resolution: {integrity: sha512-XFWRsTGLCfQZhpRlWAmmBfznWyKL72dXY8UFTK+gmI2SOFdxQb8CJc0v/6LgNohwTKRTZZr59K9eRP3v8gCK6A==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.42':
-    resolution: {integrity: sha512-xIFSI791uRvTbhlKKZ0a92xo4zRPORZVKk91py+6bSuBxsccXeW4e6EEDwv/j3IEPgMufVIKsRSfOUUNf+u26A==}
+  '@milaboratories/pframes-rs-wasip2@1.1.50':
+    resolution: {integrity: sha512-FHv6Cksyl9q9plIhRUzNP0cQ03aZVltNh+haZ5KGVNHh9e5PgP9ndnTP06bQ1JRyQ/6Thf1NF5yw1lBXp6J+uw==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.42':
-    resolution: {integrity: sha512-94Y2FHNRjqTZmqe7U8cLM0eAZ0CSxfG9KQ9voyy+QdcqQ4bl+Fw891HGCt9BToNB6Ce938D3Dn69dLPAxAXCDw==}
+  '@milaboratories/pframes-rs-wasm@1.1.50':
+    resolution: {integrity: sha512-D7YvFltjAk+OLCC/5/U741Hipxof4v/t0cJbk+y38MJjx6PyGQhAyVP/J4XfbJgdFdTGdDidRCNGYLt/Jn8l3w==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.5
 
-  '@milaboratories/pl-client@3.11.3':
-    resolution: {integrity: sha512-SF1+Y4GTHeN0e3obxA/CfapH7KbUEcxswMYwEGLjlJ6B2582hN1//FNhZQbscvYSuohB2pdDhoGxG0Ht1TAF5w==}
+  '@milaboratories/pl-client@3.11.4':
+    resolution: {integrity: sha512-tsbZLVBC3qr3bcJ1mAvkKSJSjrOkh+OzI4EACOZ8V9eS1M08ooDF5L2JkhUPceCsNr78vgkffZFwwHIbPMtHrA==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-config@1.8.2':
     resolution: {integrity: sha512-FG9rlAKDf1rwlg+3G9OG2bCKISNp6ajM27W7ODDSsWE4MSCVxhYB172UusbohY2RDmaD9GI5pDKO5O9uoHQCCA==}
 
-  '@milaboratories/pl-deployments@3.0.6':
-    resolution: {integrity: sha512-g4H0SLOL5/K7KEDAwu93oGpzcA7xXKCIVSwz6vGxDt8w178Ja7eXwtqbQ2nqB28sUc6GVUrJpDPuVBZuf6iFmQ==}
+  '@milaboratories/pl-deployments@3.0.7':
+    resolution: {integrity: sha512-llf3PeNr7/+t7I4LDwgSzqt+fcrV8YWbzv1LWJXUXOL2VF3wArBoSLmzFr3SiRD5hIUcCDEA3QHWXwXTzth0kQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.15.5':
-    resolution: {integrity: sha512-IAOMx9PTeIKRzWHqdplch5EECBjYTUcwJ4YbRkwI4LhjpG8rxChYkKiUQnLvMtA1iGo+uALWBI4I8Ea4V+HRJA==}
+  '@milaboratories/pl-drivers@1.16.0':
+    resolution: {integrity: sha512-9yAJ8YhE4fxFgqEllrHCsXCBdGNSF7c0SCQ2PIi2tYRR3++Dll7g+zOA0WDaOB+8eBAxYiqFvhsdfbCizwCCqw==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-errors@1.4.21':
-    resolution: {integrity: sha512-WWubKsRbPlj3GsIeKQ+acFU/a3qQUHKtn4lddrSrRAwcg+tJ80c2r1nbyCdYXUnSRrRCdjnRlA1af5g71d7M0A==}
+  '@milaboratories/pl-errors@1.4.22':
+    resolution: {integrity: sha512-A4jEhyXEeHb03aRpUGWxILGTfNwYii/BgmoZ3TVv5q0iWnApoiVUoy/MXtaed4QeUs8FZlOhZfOO5AKq1yaXrQ==}
 
   '@milaboratories/pl-healthcheck@1.0.1':
     resolution: {integrity: sha512-eiYd/TFm18SW4EY8vkI3c+fcPnjUu3Hd1GnPLWCN8U+dNmp/tnrzfeCgaY4xO/s0vkHNX9E7IrsQiMg2Ioz4rw==}
@@ -1236,31 +1361,28 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.64.12':
-    resolution: {integrity: sha512-Synx0xEV8YCtUflXAQgNndQhhjKSyrZXRH/rPaJpq4UzyCru3j9FcNdcEC4w3Vt92vIgKEoQl/TxWi3zU7XnVQ==}
+  '@milaboratories/pl-middle-layer@1.64.31':
+    resolution: {integrity: sha512-5ElnNEog3PvGBe3NIOIi3BhOhAWYnikHu4eV5Ms6fBTnag8TklZPF3of4RnvtFI+oSroQ0immqNmufleLoqOkw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.4.6':
-    resolution: {integrity: sha512-a5MKpd+OV9hCGykHpcPMSL5njzkrKe3qplp2a+vOaajDQz6MujM8750nvlGRhBki56z1sI34/LbcET/uVfGo/A==}
+  '@milaboratories/pl-model-backend@1.4.7':
+    resolution: {integrity: sha512-OSe9s7HJ5bVbggG9gF5/sPnvW3gqQsICeIQeT+pe2i/HvxNoL/YNvvJhcNaGc3D+TNKzu4GIlaWaRQfiYffzNQ==}
 
-  '@milaboratories/pl-model-common@1.45.0':
-    resolution: {integrity: sha512-T3yCPY112J/+b5OjK2qVaJ/sk5rdyA8GNa87YojwZmO9P8KAgngOZrnjmBTnyW3Z64iK4N6Lt64+c0AnPB9sig==}
+  '@milaboratories/pl-model-common@1.46.1':
+    resolution: {integrity: sha512-ABOz/w7dA4t2zUpZHXI74MTNW6LmPFSLxgfhOPFdO6vodIY8draVN+ag2U21WlYIoSgdJwSXJrXJWdu1cefrIg==}
 
-  '@milaboratories/pl-model-common@1.46.0':
-    resolution: {integrity: sha512-ieKPAQn40j731NuRWv+wRpgs3W0doxtQC3+aQC6dZQIo5kIzYqfZGrVQQUyNwfGbk3T3cCLH8dS8YZcBOEyIBQ==}
+  '@milaboratories/pl-model-middle-layer@1.30.5':
+    resolution: {integrity: sha512-TSpemA65REZay1ObnuwV3QLIjN46Iluy0HUu/aiHMQ1d1BFAG2vrgvonQqTnxp7UKQYOr9RGJg/QDYG/+UNKMw==}
 
-  '@milaboratories/pl-model-middle-layer@1.29.0':
-    resolution: {integrity: sha512-xUZnvi6yvU2iegXxU/alECmyxlG0RZxRP5gcUO9CfJ3kmx48NFYmDSLsolxtmunV0GYsMb3HjeMMe2oiH6ey7w==}
+  '@milaboratories/pl-model-middle-layer@1.30.6':
+    resolution: {integrity: sha512-x6cj1sNAayz80odDf6RbXnJDgj01Lc+NB+5IVyMk65o3cGt6ml0IbiqaDXGMJYUDkt1JSAj3EQpPha2YDDfYQg==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.0':
-    resolution: {integrity: sha512-OmoCfGd1eUySI3ILP6rGfytbBgUOd9Jw3HuCCiLGHbV8qevtiV1DwqohWp36KHGFCfpmtaiQyV2Q3Y5+3bdUJQ==}
-
-  '@milaboratories/pl-tree@1.12.11':
-    resolution: {integrity: sha512-lgBkgH1c5z7aVO/NufW6v+9/gerOKK4HF5U7vFjFQ3mfSJzo8ahy0R73Pzc3ZZqnHknPEAsdDY1EDe2p20xyJA==}
+  '@milaboratories/pl-tree@1.12.12':
+    resolution: {integrity: sha512-IREZbJZ1F7QerUyzcfPg0HQCae/FPGXoNbxwsecLC+JiPAVaRdcz+uNTpBlPVNEeI9BT88fJmDhfjts5bbeE7A==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ptabler-expression-js@1.2.29':
-    resolution: {integrity: sha512-f0tBLSPGj3Zuixm+lhocZNQCMc5rB5h+26QhhLneLiPMYZtDmLTs3PSJX10ZVucBfZKoevtjyZWc5XKnATM2rA==}
+  '@milaboratories/ptabler-expression-js@1.2.30':
+    resolution: {integrity: sha512-6yRo0T6rpt14WEC++F+uuFGunnGF8ApCeKnvkysTsKxo+hALGPIQbobcTFN1gtQADnK6DI6huWQ6MxQpjBgbuQ==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1276,8 +1398,8 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
-  '@milaboratories/ts-builder@1.5.0':
-    resolution: {integrity: sha512-tSLwqZ5dfmiXwriCYh2LI++N3AfB2RR5E30TSQRYd1ovC9fMZ9eGCZ3WskQ1h0p5+dUeSKGkDlgZFNF1wO1TTQ==}
+  '@milaboratories/ts-builder@1.5.2':
+    resolution: {integrity: sha512-aSqGW/3JdlQrnIYJVQR2z9bO+iYSGHg84xzXW0kfVo15dewvlfckhVs/4YVhTTZdO5xbgfhEsk370q1FcOgNaw==}
     hasBin: true
 
   '@milaboratories/ts-configs@1.2.3':
@@ -1290,8 +1412,8 @@ packages:
     resolution: {integrity: sha512-HK3AmNZl2fOzMHot2+ihKsOC+fluwhl5261VTn1zGS3LRpmC9bCk/po8SzsVmg79ccI5nESFTdz+BRaLsXncmQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.15.0':
-    resolution: {integrity: sha512-U9kSIX8kEBe2p/UJ7TWASRdeTEgo9ARzRLRiH+e2Do5L8yn2fUDzNnoLpoarbdVLaLG2uPh1SHnteVJsl/W+9g==}
+  '@milaboratories/uikit@2.15.7':
+    resolution: {integrity: sha512-R1bHkxgYokVB7QKkVTAC3Zmdv2acskOGqd/vw/tpg0xsGKO2aUQ4k+gEp0dEsC4yf4nA0zU9Dd6oNGJ1NA3NeQ==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -1616,11 +1738,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3@1.7.9':
     resolution: {integrity: sha512-erlYStN9cZ97tvzm5C+yBq46mjeXp9T0QhuhEI03a/HA4R296o0QFMr9opim5/CS3BpdWf++QJJtqqypOYdaKw==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.13':
-    resolution: {integrity: sha512-O9iCxnQwh0EtSWhu+GV4z9WSO5MvUqW6ob746nsSPizxzRarNZSSboAj9rRo3zp5ZQhI0wGuFnpMglgtLBxydg==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.14':
+    resolution: {integrity: sha512-BBbmfUi3fS40HmMbYKGuRNgSPo4kAk/vk+dUK3fyabbjGncKZTm9W4vZlqH2JJX0VECIROR4FrvGvF91yRyVwg==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.0':
-    resolution: {integrity: sha512-hxmUV8kDFgfHtJuRTwIEwsVbFfT06imjnZbf+Ycbt2iopqKpZGOZXvlLKSVrEl1oYcZBMovGrTZmOs7mKgyfXQ==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.2':
+    resolution: {integrity: sha512-pCPA9oa4MPZ8mw7tJRjp4Zy9e/xJL9+tWKlSVXd+PbSkAqZoPTirf1izWV/NEZhhM7w8przq4jGhbqj6ukkCRQ==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
@@ -1631,17 +1753,20 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7':
     resolution: {integrity: sha512-CqXbfFld2l6Y/8rtcZXRPsa5kqNnaS3QWUxrcfMYwNxultbhLzjZGdqSR7ejV9xRWilXpeg6DdZJIKF3+KDH8g==}
 
+  '@platforma-open/milaboratories.software-small-binaries.line-counter@1.1.1':
+    resolution: {integrity: sha512-3bqn2ZK/dV5IR0Zp678Ea9lGSHjLvfRv4lyRBYXZNO1mMWIlEhtT0bmn6FhNzBBj+MhTQfSRFnEsOejtfdN1Ew==}
+
   '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5':
     resolution: {integrity: sha512-ZdVg77pZ0Hgvxdk+mYahEyPbcTzDyz6Y7qlm6A0rJw8WCYmDVkfLqctQj0QkTLHM76oSWOHJIgD07ZxORjjgwA==}
 
   '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5':
     resolution: {integrity: sha512-x6WOZ8S3uLXzmwliCF500hw7VQ4A9U3VBbESjJlPia26aU91FqB3ylKyH2fEyTiVw2wADlTYuui1tHX47iS5Lw==}
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
-    resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
+  '@platforma-open/milaboratories.software-small-binaries@2.1.1':
+    resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
-  '@platforma-sdk/block-tools@2.10.9':
-    resolution: {integrity: sha512-YoTzHiJaL1MOVetI37OFVSnVK/7HDstyjHPc2gP3UIZHV3ljczwI1xPB/fST8MphzYvb0k2WyTo9LhATi6xG3g==}
+  '@platforma-sdk/block-tools@2.11.0':
+    resolution: {integrity: sha512-zJAPVOsgB/XvnlmrhiJUAHDl+MBSolo87nLIQVc+r6oQDDrpySUX4ztuOv/W9i9tnhjoeVeLtbySifmhdAn+Rg==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1660,26 +1785,26 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.78.9':
-    resolution: {integrity: sha512-LBlFktABPaQIDFqgI1YyIxQakIGJwglKm/TYUNBPm3TWmLkManYIoiRKp8yKy43h3N9Xd4wJ9JJ8fM7k90yxuA==}
+  '@platforma-sdk/model@1.79.6':
+    resolution: {integrity: sha512-aLgxJQQj07+uNYXiQHvFwFG34tgDC+NxvihMJ89dYKdgLPGDMlamIN4bxXco4W3uFqujQNTOqMed7cMeF3UYxA==}
 
   '@platforma-sdk/package-builder@3.13.0':
     resolution: {integrity: sha512-5dMFx1S8cotsWd9rccJlyRH00j43f9JFzLmuMGqwKCdfv+T0TADBWvbFRv1oD+kr5gRGj++Ud5GUIVVUUr6suw==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@4.0.7':
-    resolution: {integrity: sha512-e7ORwogln4onH+2jTKsqPJY7gz0nrKDuVFRnbBQC938xMenL2kiav1LHlQkE37HKSeVpZR6JSu7pi/PuqHVhDg==}
+  '@platforma-sdk/tengo-builder@4.0.8':
+    resolution: {integrity: sha512-FOMj0LCBRWHKuKKOHUxqZX3uhaC4OayGzw0YBxbye0b7d7uwhH2KjdrkO70uHRy64z4U85pjIR2TrwAQC8qUgQ==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.78.10':
-    resolution: {integrity: sha512-AU6MrGM/k1mnKQNJNk03EKhbNJiGh5euz5oI2tY4rQEx6696bTP6tCLQxR4IWuewbiJqVnYPkNYdr3DDYcqSaQ==}
+  '@platforma-sdk/test@1.79.13':
+    resolution: {integrity: sha512-oOuFmVYGywk7Y1h0P5PbdGSSsI3HbGGToy44uDUrFGcpqMHIVC0j20mTVKz8rzaiWkIVBhEznPAblywlq3ltFw==}
 
-  '@platforma-sdk/ui-vue@1.78.11':
-    resolution: {integrity: sha512-tijRISw3F/pBy/cFskj8IDnL1znSaCvkyezcsLo9G7FnnydMpPpCc3whnV3rLS8g7/Qyp9pXxY8t6j6WBj7qcQ==}
+  '@platforma-sdk/ui-vue@1.79.11':
+    resolution: {integrity: sha512-i5rC0xfdKNRTDRNO53l9/Xte0gIJDBrKk59f3pHXrUBhxef5CnNd9tqdWAu7Dw+6SZT2cQmS3+QvfvdqzbkHFw==}
 
-  '@platforma-sdk/workflow-tengo@6.3.2':
-    resolution: {integrity: sha512-A4K8HVqdET5BFP8rbhZaEChTinIefHQ4f6NpdGCvi/nf8AP9+ZR6c8JsS6UglXHNp6ITdOkJfybu34CKnH9azw==}
+  '@platforma-sdk/workflow-tengo@6.6.3':
+    resolution: {integrity: sha512-2H83hEd+t8pIcSpz0anmWb0wesEcoXCYl9HSOcfQL9b0ro6EDf+PwyafXtmbXl2kMtkpccigbhDGZdDhoMpr7w==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -3951,8 +4076,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/language-core@3.2.6':
-    resolution: {integrity: sha512-xYYYX3/aVup576tP/23sEUpgiEnujrENaoNRbaozC1/MA9I6EGFQRJb4xrt/MmUCAGlxTKL2RmT8JLTPqagCkg==}
+  '@vue/language-core@3.3.5':
+    resolution: {integrity: sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==}
 
   '@vue/reactivity@3.5.24':
     resolution: {integrity: sha512-BM8kBhtlkkbnyl4q+HiF5R5BL0ycDPfihowulm02q3WYp2vxgPcJuZO866qa/0u3idbMntKEtVNuAUp5bw4teg==}
@@ -4133,8 +4258,8 @@ packages:
   alien-signals@0.4.14:
     resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
 
-  alien-signals@3.1.2:
-    resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -4267,11 +4392,21 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
   bl@1.2.3:
     resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -4361,6 +4496,9 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -4376,6 +4514,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4593,6 +4735,10 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   decompress-tar@4.1.1:
     resolution: {integrity: sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==}
     engines: {node: '>=4'}
@@ -4612,6 +4758,10 @@ packages:
   decompress@4.2.1:
     resolution: {integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==}
     engines: {node: '>=4'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -4836,6 +4986,10 @@ packages:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
     engines: {node: '>=6'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -4902,6 +5056,9 @@ packages:
   file-type@6.2.0:
     resolution: {integrity: sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==}
     engines: {node: '>=4'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
@@ -4992,6 +5149,9 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -5445,6 +5605,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
@@ -5479,6 +5643,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
@@ -5495,6 +5662,10 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   nan@2.24.0:
     resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
 
@@ -5503,11 +5674,18 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -5726,6 +5904,12 @@ packages:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5781,6 +5965,10 @@ packages:
 
   rbush@4.0.1:
     resolution: {integrity: sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -5975,6 +6163,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -6055,6 +6249,10 @@ packages:
     resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
     engines: {node: '>=0.10.0'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -6078,12 +6276,19 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
   tar-fs@3.1.1:
     resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
 
   tar-stream@1.6.2:
     resolution: {integrity: sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==}
     engines: {node: '>= 0.8.0'}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
@@ -6164,6 +6369,9 @@ packages:
   tsyringe@4.10.0:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo-darwin-64@2.7.2:
     resolution: {integrity: sha512-dxY3X6ezcT5vm3coK6VGixbrhplbQMwgNsCsvZamS/+/6JiebqW9DKt4NwpgYXhDY2HdH00I7FWs3wkVuan4rA==}
@@ -6538,8 +6746,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  vue-tsc@3.2.6:
-    resolution: {integrity: sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q==}
+  vue-tsc@3.3.5:
+    resolution: {integrity: sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -6603,6 +6811,10 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -6655,6 +6867,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -7779,10 +7995,249 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/checkbox@4.3.2(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/confirm@5.1.21(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/confirm@5.1.21(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/core@10.3.2(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/core@10.3.2(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/editor@4.2.23(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.10.4)
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/editor@4.2.23(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.0.3)
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/expand@4.0.23(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/expand@4.0.23(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/external-editor@1.0.3(@types/node@24.10.4)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 24.10.4
+
   '@inquirer/external-editor@1.0.3(@types/node@25.0.3)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/input@4.3.1(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/number@3.0.23(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/number@3.0.23(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/password@4.0.23(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/password@4.0.23(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/prompts@7.10.1(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.10.4)
+      '@inquirer/confirm': 5.1.21(@types/node@24.10.4)
+      '@inquirer/editor': 4.2.23(@types/node@24.10.4)
+      '@inquirer/expand': 4.0.23(@types/node@24.10.4)
+      '@inquirer/input': 4.3.1(@types/node@24.10.4)
+      '@inquirer/number': 3.0.23(@types/node@24.10.4)
+      '@inquirer/password': 4.0.23(@types/node@24.10.4)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.10.4)
+      '@inquirer/search': 3.2.2(@types/node@24.10.4)
+      '@inquirer/select': 4.4.2(@types/node@24.10.4)
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/prompts@7.10.1(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@25.0.3)
+      '@inquirer/confirm': 5.1.21(@types/node@25.0.3)
+      '@inquirer/editor': 4.2.23(@types/node@25.0.3)
+      '@inquirer/expand': 4.0.23(@types/node@25.0.3)
+      '@inquirer/input': 4.3.1(@types/node@25.0.3)
+      '@inquirer/number': 3.0.23(@types/node@25.0.3)
+      '@inquirer/password': 4.0.23(@types/node@25.0.3)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.0.3)
+      '@inquirer/search': 3.2.2(@types/node@25.0.3)
+      '@inquirer/select': 4.4.2(@types/node@25.0.3)
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/rawlist@4.1.11(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/rawlist@4.1.11(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/search@3.2.2(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/search@3.2.2(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/select@4.4.2(@types/node@24.10.4)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.10.4)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.4)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/select@4.4.2(@types/node@25.0.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.0.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.0.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.0.3
+
+  '@inquirer/type@3.0.10(@types/node@24.10.4)':
+    optionalDependencies:
+      '@types/node': 24.10.4
+
+  '@inquirer/type@3.0.10(@types/node@25.0.3)':
     optionalDependencies:
       '@types/node': 25.0.3
 
@@ -7947,14 +8402,14 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.0)(@platforma-sdk/model@1.78.9)(@platforma-sdk/ui-vue@1.78.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.9
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.0)(@platforma-sdk/model@1.78.9)
-      '@platforma-sdk/model': 1.78.9
-      '@platforma-sdk/ui-vue': 1.78.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)
+      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/ui-vue': 1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.9.0(vue@3.5.26(typescript@5.6.3))
@@ -8011,13 +8466,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.16(@milaboratories/pl-model-common@1.46.0)(@platforma-sdk/model@1.78.9)(@platforma-sdk/ui-vue@1.78.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.16(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.3
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.0)(@platforma-sdk/model@1.78.9)
-      '@platforma-sdk/model': 1.78.9
-      '@platforma-sdk/ui-vue': 1.78.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)
+      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/ui-vue': 1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.26(typescript@5.6.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -8027,13 +8482,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/pf-driver@1.7.4(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.7.11(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-node': 1.1.42
-      '@milaboratories/pframes-rs-wasm': 1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.0)(@milaboratories/pl-model-middle-layer@1.30.0)
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/pl-model-middle-layer': 1.30.0
+      '@milaboratories/pframes-rs-node': 1.1.50
+      '@milaboratories/pframes-rs-wasm': 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.1)(@milaboratories/pl-model-middle-layer@1.30.6)
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
       '@milaboratories/ts-helpers': 1.8.3
       es-toolkit: 1.43.0
       lru-cache: 11.2.4
@@ -8042,57 +8497,58 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.0)(@platforma-sdk/model@1.78.9)':
+  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.0
-      '@platforma-sdk/model': 1.78.9
+      '@milaboratories/pl-model-common': 1.46.1
+      '@platforma-sdk/model': 1.79.6
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-spec-driver@1.4.6(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.4.13(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.0)(@milaboratories/pl-model-middle-layer@1.30.0)
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/pl-model-middle-layer': 1.30.0
+      '@milaboratories/pframes-rs-wasm': 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.1)(@milaboratories/pl-model-middle-layer@1.30.6)
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-node@1.1.42':
+  '@milaboratories/pframes-rs-node@1.1.50':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.42
-      '@milaboratories/pl-model-common': 1.45.0
+      '@milaboratories/pframes-rs-serv': 1.1.50
+      '@milaboratories/pl-model-common': 1.46.1
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.42':
+  '@milaboratories/pframes-rs-serv@1.1.50':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.5
+      better-sqlite3: 12.10.0
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.42': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.50': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.0)(@milaboratories/pl-model-middle-layer@1.30.0)':
+  '@milaboratories/pframes-rs-wasm@1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.1)(@milaboratories/pl-model-middle-layer@1.30.6)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.42
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/pl-model-middle-layer': 1.30.0
+      '@milaboratories/pframes-rs-wasip2': 1.1.50
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
 
-  '@milaboratories/pl-client@3.11.3':
+  '@milaboratories/pl-client@3.11.4':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.0
+      '@milaboratories/pl-model-common': 1.46.1
       '@milaboratories/ts-helpers': 1.8.3
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
@@ -8112,12 +8568,12 @@ snapshots:
       upath: 2.0.1
       yaml: 2.8.2
 
-  '@milaboratories/pl-deployments@3.0.6':
+  '@milaboratories/pl-deployments@3.0.7':
     dependencies:
       '@milaboratories/pl-config': 1.8.2
       '@milaboratories/pl-healthcheck': 1.0.1
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.0
+      '@milaboratories/pl-model-common': 1.46.1
       '@milaboratories/ts-helpers': 1.8.3
       decompress: 4.2.1
       ssh2: 1.17.0
@@ -8127,14 +8583,14 @@ snapshots:
       yaml: 2.8.2
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.15.5':
+  '@milaboratories/pl-drivers@1.16.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/computable': 2.9.5
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-client': 3.11.3
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/pl-tree': 1.12.11
+      '@milaboratories/pl-client': 3.11.4
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-tree': 1.12.12
       '@milaboratories/ts-helpers': 1.8.3
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
@@ -8142,6 +8598,7 @@ snapshots:
       '@protobuf-ts/runtime-rpc': 2.11.1
       decompress: 4.2.1
       denque: 2.1.0
+      lru-cache: 11.2.4
       openapi-fetch: 0.15.0
       tar-fs: 3.1.1
       undici: 7.16.0
@@ -8157,9 +8614,9 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-errors@1.4.21':
+  '@milaboratories/pl-errors@1.4.22':
     dependencies:
-      '@milaboratories/pl-client': 3.11.3
+      '@milaboratories/pl-client': 3.11.4
       '@milaboratories/ts-helpers': 1.8.3
       zod: 3.25.76
 
@@ -8175,28 +8632,28 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.64.12(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pl-middle-layer@1.64.31(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pf-driver': 1.7.4(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.4.6(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pframes-rs-node': 1.1.42
-      '@milaboratories/pframes-rs-wasm': 1.1.42(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.0)(@milaboratories/pl-model-middle-layer@1.30.0)
-      '@milaboratories/pl-client': 3.11.3
-      '@milaboratories/pl-deployments': 3.0.6
-      '@milaboratories/pl-drivers': 1.15.5
-      '@milaboratories/pl-errors': 1.4.21
+      '@milaboratories/pf-driver': 1.7.11(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.4.13(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pframes-rs-node': 1.1.50
+      '@milaboratories/pframes-rs-wasm': 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.1)(@milaboratories/pl-model-middle-layer@1.30.6)
+      '@milaboratories/pl-client': 3.11.4
+      '@milaboratories/pl-deployments': 3.0.7
+      '@milaboratories/pl-drivers': 1.16.0
+      '@milaboratories/pl-errors': 1.4.22
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.6
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/pl-model-middle-layer': 1.30.0
-      '@milaboratories/pl-tree': 1.12.11
+      '@milaboratories/pl-model-backend': 1.4.7
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
+      '@milaboratories/pl-tree': 1.12.12
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.3
-      '@platforma-sdk/block-tools': 2.10.9
-      '@platforma-sdk/model': 1.78.9
-      '@platforma-sdk/workflow-tengo': 6.3.2
+      '@platforma-sdk/block-tools': 2.11.0(@types/node@25.0.3)
+      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/workflow-tengo': 6.6.3
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.43.0
@@ -8209,6 +8666,7 @@ snapshots:
       zod: 3.25.76
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
+      - '@types/node'
       - aws-crt
       - bare-abort-controller
       - bare-buffer
@@ -8216,55 +8674,48 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.4.6':
+  '@milaboratories/pl-model-backend@1.4.7':
     dependencies:
-      '@milaboratories/pl-client': 3.11.3
+      '@milaboratories/pl-client': 3.11.4
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.45.0':
+  '@milaboratories/pl-model-common@1.46.1':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.46.0':
+  '@milaboratories/pl-model-middle-layer@1.30.5':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-error-like': 1.12.10
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-middle-layer@1.29.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.45.0
+      '@milaboratories/pl-model-common': 1.46.1
       es-toolkit: 1.43.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.0':
+  '@milaboratories/pl-model-middle-layer@1.30.6':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.0
+      '@milaboratories/pl-model-common': 1.46.1
       es-toolkit: 1.43.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.12.11':
+  '@milaboratories/pl-tree@1.12.12':
     dependencies:
       '@milaboratories/computable': 2.9.5
-      '@milaboratories/pl-client': 3.11.3
-      '@milaboratories/pl-errors': 1.4.21
+      '@milaboratories/pl-client': 3.11.4
+      '@milaboratories/pl-errors': 1.4.22
       '@milaboratories/ts-helpers': 1.8.3
       denque: 2.1.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.2.29':
+  '@milaboratories/ptabler-expression-js@1.2.30':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.13
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.14
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -8274,7 +8725,7 @@ snapshots:
 
   '@milaboratories/tengo-tester@1.6.4': {}
 
-  '@milaboratories/ts-builder@1.5.0(@types/node@24.10.4)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.5.2(@types/node@24.10.4)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)':
     dependencies:
       '@milaboratories/ts-configs': 1.2.3
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.26(typescript@5.6.3))
@@ -8284,7 +8735,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.13
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.10.4)(rollup@4.55.1)
       typescript: 5.9.3
@@ -8293,7 +8744,7 @@ snapshots:
       vite-plugin-dts: 4.5.4(@types/node@24.10.4)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2))
       vite-plugin-externalize-deps: 0.10.0(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2))
       vite-plugin-lib-inject-css: 2.2.2(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2))
-      vue-tsc: 3.2.6(typescript@5.9.3)
+      vue-tsc: 3.3.5(typescript@5.9.3)
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@types/node'
@@ -8315,7 +8766,7 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-builder@1.5.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.5.2(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.2)':
     dependencies:
       '@milaboratories/ts-configs': 1.2.3
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.24(typescript@5.6.3))
@@ -8325,7 +8776,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.13
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@25.0.3)(rollup@4.55.1)
       typescript: 5.9.3
@@ -8334,7 +8785,7 @@ snapshots:
       vite-plugin-dts: 4.5.4(@types/node@25.0.3)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
       vite-plugin-externalize-deps: 0.10.0(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
       vite-plugin-lib-inject-css: 2.2.2(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
-      vue-tsc: 3.2.6(typescript@5.9.3)
+      vue-tsc: 3.3.5(typescript@5.9.3)
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@types/node'
@@ -8369,10 +8820,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.0(typescript@5.6.3)':
+  '@milaboratories/uikit@2.15.7(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.78.9
+      '@platforma-sdk/model': 1.79.6
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8679,11 +9130,11 @@ snapshots:
       '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.5.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.5
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.13':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.14':
     dependencies:
-      '@milaboratories/pl-model-common': 1.46.0
+      '@milaboratories/pl-model-common': 1.46.1
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.0': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.2': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
@@ -8691,24 +9142,28 @@ snapshots:
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7': {}
 
+  '@platforma-open/milaboratories.software-small-binaries.line-counter@1.1.1': {}
+
   '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5': {}
 
   '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5': {}
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
+  '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     dependencies:
       '@platforma-open/milaboratories.software-small-binaries.hello-world': 1.1.7
       '@platforma-open/milaboratories.software-small-binaries.hello-world-py': 1.0.10
+      '@platforma-open/milaboratories.software-small-binaries.line-counter': 1.1.1
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.10.9':
+  '@platforma-sdk/block-tools@2.11.0(@types/node@24.10.4)':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
+      '@inquirer/prompts': 7.10.1(@types/node@24.10.4)
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.6
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/pl-model-middle-layer': 1.30.0
+      '@milaboratories/pl-model-backend': 1.4.7
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.3
       '@milaboratories/ts-helpers-oclif': 1.1.42
@@ -8722,6 +9177,31 @@ snapshots:
       yaml: 2.8.2
       zod: 3.25.76
     transitivePeerDependencies:
+      - '@types/node'
+      - aws-crt
+
+  '@platforma-sdk/block-tools@2.11.0(@types/node@25.0.3)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@inquirer/prompts': 7.10.1(@types/node@25.0.3)
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-backend': 1.4.7
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers-oclif': 1.1.42
+      '@oclif/core': 4.8.0
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
+      canonicalize: 2.1.0
+      lru-cache: 11.2.4
+      mime-types: 2.1.35
+      tar: 7.5.2
+      undici: 7.16.0
+      yaml: 2.8.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@types/node'
       - aws-crt
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -8739,13 +9219,13 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.51.0(eslint@9.39.2)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.78.9':
+  '@platforma-sdk/model@1.79.6':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/pl-model-middle-layer': 1.30.0
-      '@milaboratories/ptabler-expression-js': 1.2.29
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
+      '@milaboratories/ptabler-expression-js': 1.2.30
       canonicalize: 2.1.0
       es-toolkit: 1.43.0
       fast-json-patch: 3.1.1
@@ -8770,24 +9250,24 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@platforma-sdk/tengo-builder@4.0.7':
+  '@platforma-sdk/tengo-builder@4.0.8':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.4.6
+      '@milaboratories/pl-model-backend': 1.4.7
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.8.3
       '@oclif/core': 4.8.0
       winston: 3.19.0
 
-  '@platforma-sdk/test@1.78.10(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.79.13(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))':
     dependencies:
       '@milaboratories/computable': 2.9.5
-      '@milaboratories/pl-client': 3.11.3
-      '@milaboratories/pl-middle-layer': 1.64.12(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-tree': 1.12.11
-      '@platforma-sdk/model': 1.78.9
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))
-      vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+      '@milaboratories/pl-client': 3.11.4
+      '@milaboratories/pl-middle-layer': 1.64.31(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)
+      '@milaboratories/pl-tree': 1.12.12
+      '@platforma-sdk/model': 1.79.6
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)))
+      vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - '@edge-runtime/vm'
@@ -8809,12 +9289,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.78.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.4.6(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.46.0
-      '@milaboratories/uikit': 2.15.0(typescript@5.6.3)
-      '@platforma-sdk/model': 1.78.9
+      '@milaboratories/pf-spec-driver': 1.4.13(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/uikit': 2.15.7(typescript@5.6.3)
+      '@platforma-sdk/model': 1.79.6
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -8845,13 +9325,13 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@6.3.2':
+  '@platforma-sdk/workflow-tengo@6.6.3':
     dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.42
+      '@milaboratories/pframes-rs-wasip2': 1.1.50
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.0
+      '@platforma-open/milaboratories.software-ptabler': 2.1.2
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
-      '@platforma-open/milaboratories.software-small-binaries': 2.0.4
+      '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
     dependencies:
@@ -11796,7 +12276,7 @@ snapshots:
       vite: 8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)
       vue: 3.5.24(typescript@5.6.3)
 
-  '@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)))':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -11808,7 +12288,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)
+      vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -11990,12 +12470,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@vue/language-core@3.2.6':
+  '@vue/language-core@3.3.5':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.26
       '@vue/shared': 3.5.26
-      alien-signals: 3.1.2
+      alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
       picomatch: 4.0.4
@@ -12180,7 +12660,7 @@ snapshots:
 
   alien-signals@0.4.14: {}
 
-  alien-signals@3.1.2: {}
+  alien-signals@3.2.1: {}
 
   ansi-colors@4.1.3: {}
 
@@ -12308,12 +12788,27 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@12.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   birpc@4.0.0: {}
 
   bl@1.2.3:
     dependencies:
       readable-stream: 2.3.8
       safe-buffer: 5.2.1
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   boolbase@1.0.0: {}
 
@@ -12405,6 +12900,8 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  chownr@1.1.4: {}
+
   chownr@3.0.0: {}
 
   ci-info@3.9.0: {}
@@ -12414,6 +12911,8 @@ snapshots:
       escape-string-regexp: 4.0.0
 
   cli-spinners@2.9.2: {}
+
+  cli-width@4.1.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -12603,6 +13102,10 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   decompress-tar@4.1.1:
     dependencies:
       file-type: 5.2.0
@@ -12640,6 +13143,8 @@ snapshots:
       make-dir: 1.3.0
       pify: 2.3.0
       strip-dirs: 2.1.0
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -12930,6 +13435,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-eof: 1.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
@@ -12981,6 +13488,8 @@ snapshots:
   file-type@5.2.0: {}
 
   file-type@6.2.0: {}
+
+  file-uri-to-path@1.0.0: {}
 
   filelist@1.0.4:
     dependencies:
@@ -13081,6 +13590,8 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -13475,6 +13986,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.0.3:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
@@ -13507,6 +14020,8 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  mkdirp-classic@0.5.3: {}
+
   mlly@1.8.0:
     dependencies:
       acorn: 8.15.0
@@ -13522,14 +14037,22 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
+  mute-stream@2.0.0: {}
+
   nan@2.24.0:
     optional: true
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   nice-try@1.0.5: {}
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.7.3
 
   node-fetch@2.7.0:
     dependencies:
@@ -13751,6 +14274,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -13810,6 +14348,13 @@ snapshots:
   rbush@4.0.1:
     dependencies:
       quickselect: 3.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -13879,7 +14424,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -13894,7 +14439,7 @@ snapshots:
       rolldown: 1.0.0-rc.13
     optionalDependencies:
       typescript: 5.9.3
-      vue-tsc: 3.2.6(typescript@5.9.3)
+      vue-tsc: 3.3.5(typescript@5.9.3)
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -14044,6 +14589,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   slash@3.0.0: {}
 
   sortablejs@1.15.6: {}
@@ -14127,6 +14680,8 @@ snapshots:
 
   strip-eof@1.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strnum@2.1.2: {}
@@ -14142,6 +14697,13 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tapable@2.3.0: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
 
   tar-fs@3.1.1:
     dependencies:
@@ -14164,6 +14726,14 @@ snapshots:
       readable-stream: 2.3.8
       to-buffer: 1.2.2
       xtend: 4.0.2
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tar-stream@3.1.7:
     dependencies:
@@ -14239,6 +14809,10 @@ snapshots:
   tsyringe@4.10.0:
     dependencies:
       tslib: 1.14.1
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo-darwin-64@2.7.2:
     optional: true
@@ -14556,7 +15130,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)):
+  vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.3
       '@vitest/mocker': 4.1.3(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
@@ -14580,7 +15154,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)))
     transitivePeerDependencies:
       - msw
 
@@ -14601,10 +15175,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-tsc@3.2.6(typescript@5.9.3):
+  vue-tsc@3.3.5(typescript@5.9.3):
     dependencies:
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.2.6
+      '@vue/language-core': 3.3.5
       typescript: 5.9.3
 
   vue@3.5.24(typescript@5.6.3):
@@ -14685,6 +15259,12 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -14731,6 +15311,8 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   zip-stream@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8284,7 +8284,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.13
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.10.4)(rollup@4.55.1)
       typescript: 5.9.3
@@ -8325,7 +8325,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.13
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@25.0.3)(rollup@4.55.1)
       typescript: 5.9.3
@@ -13879,7 +13879,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.13)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,16 +8,16 @@ packages:
 
 catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
-  '@milaboratories/ts-builder': 1.5.0
+  '@milaboratories/ts-builder': 1.5.2
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 6.3.2
-  '@platforma-sdk/model': 1.78.9
-  '@platforma-sdk/ui-vue': 1.78.11
-  '@platforma-sdk/tengo-builder': 4.0.7
+  '@platforma-sdk/workflow-tengo': 6.6.3
+  '@platforma-sdk/model': 1.79.6
+  '@platforma-sdk/ui-vue': 1.79.11
+  '@platforma-sdk/tengo-builder': 4.0.8
   '@platforma-sdk/package-builder': 3.13.0
-  '@platforma-sdk/block-tools': 2.10.9
+  '@platforma-sdk/block-tools': 2.11.0
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.78.10
+  '@platforma-sdk/test': 1.79.13
   '@milaboratories/helpers': 1.14.2
   '@milaboratories/graph-maker': 1.4.6
   '@milaboratories/multi-sequence-alignment': 1.47.16

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -1032,8 +1032,11 @@ def load_embedding_matrix(path, key_col, dim_col, value_col):
 
 
 def l2_normalize(X, eps=1e-12):
-    """Row-wise L2-normalize, eps-guarded so a zero row can't 0/0. Returns float32."""
-    return (X / (np.linalg.norm(X, axis=1, keepdims=True) + eps)).astype(np.float32)
+    """Row-wise L2-normalize, eps-guarded so a zero row can't 0/0. Returns float32.
+    Uses np.maximum(norm, eps) (not norm+eps) so valid vectors stay exactly unit-norm — only a
+    near-zero row is clamped."""
+    norm = np.linalg.norm(X, axis=1, keepdims=True)
+    return (X / np.maximum(norm, eps)).astype(np.float32)
 
 
 def _select_k_for_variance(explained_variance_ratio, target=SVD_TARGET_VARIANCE):
@@ -1133,11 +1136,12 @@ def run_embedding_umap(Xn, umap_model, run_type, args):
             umap_model, run_type = create_umap_model(
                 'sklearn', args.umap_components, args.umap_neighbors, args.umap_min_dist)
 
-    np.random.seed(RANDOM_STATE)
+    # Isolated, seeded RNG (deterministic, doesn't touch global numpy state) — matches _fit_sample.
+    rng = np.random.default_rng(RANDOM_STATE)
     if n > UMAP_FIT_MAX_SAMPLE_SIZE:
         print(f"Fit sample ({n}) > {UMAP_FIT_MAX_SAMPLE_SIZE}. "
               f"Sampling {UMAP_FIT_MAX_SAMPLE_SIZE} vectors for UMAP fitting.")
-        idx = np.random.choice(n, size=UMAP_FIT_MAX_SAMPLE_SIZE, replace=False)
+        idx = rng.choice(n, size=UMAP_FIT_MAX_SAMPLE_SIZE, replace=False)
         umap_model.fit(Xn[idx])
     else:
         umap_model.fit(Xn)
@@ -1212,8 +1216,6 @@ def run_embedding_mode(args, output_path):
     if n_degenerate:
         print(f"Warning: {n_degenerate} unique vector(s) near-zero norm post-PCA "
               f"(centered-PCA residual ≈ dataset mean) — excluded from the UMAP fit, null coords.")
-    Xn = l2_normalize(Xr)
-
     n_valid = int(valid.sum())
     if n_valid < min_required:
         print(f"Warning: Not enough non-degenerate vectors for UMAP "
@@ -1223,12 +1225,16 @@ def run_embedding_mode(args, output_path):
                                      "UMAP analysis skipped due to insufficient non-degenerate vectors.")
         return
 
+    # Normalize only the valid (non-degenerate) rows we actually fit/transform — avoids dividing a
+    # near-zero residual by eps and amplifying numerical noise into rows we'd then discard.
+    Xn_valid = l2_normalize(Xr[valid])
+
     umap_model, run_type = create_umap_model(
         args.umap_backend, args.umap_components, args.umap_neighbors, args.umap_min_dist)
 
     print(f"Running UMAP on {n_valid} non-degenerate unique vectors "
           f"(L2-normalized, Euclidean ≡ cosine)...")
-    coords_valid = run_embedding_umap(Xn[valid], umap_model, run_type, args)
+    coords_valid = run_embedding_umap(Xn_valid, umap_model, run_type, args)
 
     # Degenerate uniques get NaN coords; assemble the full unique-coord matrix, then broadcast to every
     # clonotype via the dedup inverse index. NaN rows surface as null coords downstream.

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -63,6 +63,7 @@ import argparse
 import functools
 import itertools
 import os
+import resource
 import sys
 import time
 
@@ -78,9 +79,15 @@ from scipy import sparse
 # Random seed for all stochastic operations (sampling, SVD, UMAP).
 RANDOM_STATE = 42
 
-# SVD configuration.
+# SVD / PCA configuration. The 95%-variance target and 500-component cap are shared by the k-mer SVD
+# path and the embedding centered-PCA path.
 SVD_TARGET_VARIANCE = 0.95
 SVD_MAX_COMPONENTS = 500
+
+# Embedding mode: a vector whose centered-PCA residual norm falls below this is "degenerate" — it sits
+# at (≈) the dataset mean, so it has no reliable direction to normalize. Excluded from the UMAP fit and
+# given null coordinates.
+DEGENERATE_NORM_THRESHOLD = 1e-8
 
 # Maximum sequences used to fit UMAP on the CPU path. Larger fit-samples are sub-sampled
 # down to this size before UMAP fitting.
@@ -636,8 +643,9 @@ def parse_args():
         description='Compute UMAP embeddings from sequences via k-mer counts and SVD.',
         formatter_class=argparse.RawTextHelpFormatter,
     )
-    parser.add_argument('-i', '--input', required=True,
-                        help='Input TSV file with sequence column(s).')
+    parser.add_argument('-i', '--input', required=False, default=None,
+                        help='Input TSV file with sequence column(s). Required for kmer/pos-kmer '
+                             'encodings; ignored for --encoding embedding (use --matrix).')
     parser.add_argument('-c', '--seq-col-start', default='sequence',
                         help='Prefix of input columns to treat as sequences (default: "sequence").')
     parser.add_argument('-u', '--umap-output', required=True,
@@ -652,13 +660,30 @@ def parse_args():
                         help='UMAP min_dist (default: 0.5).')
     parser.add_argument('--k-mer-size', type=int, default=None,
                         help='Size of k-mers (default: 3 for aminoacid, 6 for nucleotide).')
-    parser.add_argument('--encoding', choices=['kmer', 'pos-kmer'], default='kmer',
-                        help='Sequence encoding (default: kmer).\n'
-                             '  kmer:     k-mer count vectors (position-agnostic, any length).\n'
-                             '  pos-kmer: position-tagged k-mers — each (position, k-mer) pair\n'
-                             '            is a distinct feature. Variable-length sequences are\n'
-                             '            right-padded (N-term aligned) with "_" / "N" up to the\n'
-                             '            longest input. Use --k-mer-size 2 for short peptides.')
+    parser.add_argument('--encoding', choices=['kmer', 'pos-kmer', 'embedding'], default='kmer',
+                        help='Feature encoding (default: kmer).\n'
+                             '  kmer:      k-mer count vectors (position-agnostic, any length).\n'
+                             '  pos-kmer:  position-tagged k-mers — each (position, k-mer) pair\n'
+                             '             is a distinct feature. Variable-length sequences are\n'
+                             '             right-padded (N-term aligned) with "_" / "N" up to the\n'
+                             '             longest input. Use --k-mer-size 2 for short peptides.\n'
+                             '  embedding: run UMAP on learned per-clonotype embedding vectors read\n'
+                             '             from --matrix (parquet); skips k-mer counting and SVD,\n'
+                             '             reduces with centered PCA-95%% then L2-normalizes and runs\n'
+                             '             Euclidean UMAP (≡ cosine ranking).')
+    # --- Embedding mode (--encoding embedding) ---
+    parser.add_argument('--matrix', default=None,
+                        help='Long-format embedding matrix (parquet) for --encoding embedding: one row '
+                             'per (clonotype, embeddingDim) with the embedding value.')
+    parser.add_argument('--key-col', default='clonotypeKey',
+                        help='Clonotype-key column name in the embedding matrix (default: clonotypeKey).')
+    parser.add_argument('--dim-col', default='embeddingDim',
+                        help='Embedding-dimension column name in the embedding matrix (default: embeddingDim).')
+    parser.add_argument('--value-col', default='value',
+                        help='Embedding-value column name in the embedding matrix (default: value).')
+    parser.add_argument('--embedding-model', default=None,
+                        help='Embedding model identifier, logged to the processing log for provenance '
+                             '(--encoding embedding). Stamped on the output column domain by the workflow.')
     parser.add_argument('--output-dir', default='.',
                         help='Directory for output files (default: current directory).')
     parser.add_argument('--svd-backend', type=str, default='auto',
@@ -950,6 +975,315 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
 
 
 # ============================================================================
+# Embedding feature path (--encoding embedding)
+# ============================================================================
+#
+# UMAP on learned per-clonotype embedding vectors. Order is load-bearing:
+#   load matrix → vector-dedup → centered PCA-95% → L2-normalize → Euclidean UMAP.
+# Centered PCA removes ESM-2's large non-discriminative shared mean, so the post-PCA
+# L2-normalize + Euclidean (≡ cosine ranking) then measures the mean-removed residuals.
+# Reuses create_umap_model (CPU/GPU backends) but NOT run_cpu/gpu_pipeline — the matrix is already
+# materialized, so there is no per-chunk feature recompute.
+
+def load_embedding_matrix(path, key_col, dim_col, value_col):
+    """Read the long-format embedding matrix (parquet) → (X float32, keys object array).
+
+    The parquet has one row per (clonotype, embeddingDim). Rather than sorting the whole N*D-row frame
+    (a full sorted copy — the dominant memory cost at scale), the matrix is built by SCATTER: factorize
+    the clonotype key to an integer code, then place each value at X[code, dim]. This is order-
+    independent (dim positions the column, code positions the row) and avoids the sort entirely. Casting
+    the key to Categorical keeps only the unique keys + per-row codes instead of N*D expanded strings.
+
+    Keys come back in physical-code (first-appearance) order; row order does not matter downstream
+    (dedup re-sorts; the output pframe is keyed by clonotype value, not row position). Kept float32.
+
+    Completeness (the ragged-matrix check, R-equivalent): a full, duplicate-free fill requires BOTH
+    `len(vals) == n*D` (no extra/duplicate rows) AND no unfilled cell after the scatter (no missing dim).
+    embeddingDim is the producer's 0..D-1 index, used directly as the column index; D is inferred as
+    max(dim)+1."""
+    df = pl.read_parquet(path, columns=[key_col, dim_col, value_col])
+    if df.height == 0:
+        return np.empty((0, 0), dtype=np.float32), np.array([], dtype=object)
+
+    cat = df.get_column(key_col).cast(pl.Categorical)
+    keys = cat.cat.get_categories()                 # unique clonotype keys, in physical-code order
+    n = keys.len()
+    codes = cat.to_physical().to_numpy()            # per-row clonotype index 0..n-1 (aligns with `keys`)
+    dims = df.get_column(dim_col).to_numpy()         # per-row embeddingDim index
+    vals = df.get_column(value_col).cast(pl.Float32).to_numpy()
+    del df, cat
+
+    if dims.min() < 0:
+        raise ValueError(f"embeddingDim must be a 0-based index; got a negative value {int(dims.min())}.")
+    D = int(dims.max()) + 1
+
+    if vals.shape[0] != n * D:
+        raise ValueError(
+            f"Ragged embedding matrix: {vals.shape[0]} rows != n*D ({n}*{D}) — a clonotype has extra "
+            f"or duplicate (clonotype, dim) rows.")
+
+    X = np.full((n, D), np.nan, dtype=np.float32)
+    X[codes, dims] = vals                            # scatter: row = clonotype, col = embeddingDim
+    if np.isnan(X).any():
+        raise ValueError(
+            "Ragged embedding matrix: a (clonotype, dim) cell is missing — a clonotype has a partial "
+            "embedding-dimension set.")
+    return X, keys.to_numpy().astype(object)
+
+
+def l2_normalize(X, eps=1e-12):
+    """Row-wise L2-normalize, eps-guarded so a zero row can't 0/0. Returns float32."""
+    return (X / (np.linalg.norm(X, axis=1, keepdims=True) + eps)).astype(np.float32)
+
+
+def _select_k_for_variance(explained_variance_ratio, target=SVD_TARGET_VARIANCE):
+    """Smallest component count whose cumulative explained variance reaches `target`; full count if it
+    never does."""
+    cum = np.cumsum(explained_variance_ratio)
+    if np.any(cum >= target):
+        return int(np.searchsorted(cum, target) + 1)
+    return len(explained_variance_ratio)
+
+
+def _pca_reduce_sklearn(X_fit, X_all, ncomp):
+    """Centered PCA on CPU (sklearn, svd_solver='full', deterministic). Fit on X_fit, transform X_all,
+    slice to the 95%-variance k. Returns (Xr float32, k)."""
+    from sklearn.decomposition import PCA
+    print("Using CPU-based centered PCA (scikit-learn, svd_solver='full')...")
+    pca = PCA(n_components=ncomp, svd_solver='full').fit(X_fit)  # centered by default
+    k = min(_select_k_for_variance(pca.explained_variance_ratio_), ncomp)
+    return pca.transform(X_all)[:, :k].astype(np.float32), k
+
+
+def _pca_reduce_cuml(X_fit, X_all, ncomp):
+    """Centered PCA on GPU (cuML, svd_solver='full'). Net-new vs the k-mer path's sparse SVD; wrapped by
+    an OOM/error guard + CPU fallback in embedding_pca_reduce. Returns (Xr float32, k)."""
+    import cuml  # noqa: F401
+    from cuml.decomposition import PCA as cuPCA
+    print("Using GPU-accelerated centered PCA (RAPIDS cuML, svd_solver='full')...")
+    pca = cuPCA(n_components=ncomp, svd_solver='full').fit(X_fit)
+    evr = pca.explained_variance_ratio_
+    try:
+        import cupy as cp
+        evr = cp.asnumpy(evr)
+        k = min(_select_k_for_variance(np.asarray(evr)), ncomp)
+        Xr = cp.asnumpy(pca.transform(X_all))
+    except ImportError:
+        evr = np.asarray(evr)
+        k = min(_select_k_for_variance(evr), ncomp)
+        Xr = np.asarray(pca.transform(X_all))
+    return Xr[:, :k].astype(np.float32), k
+
+
+def _fit_sample(X, max_sequences, n):
+    """Seeded fit-sample for the CPU PCA fit (the dense svd_solver='full' fit on all rows is a CPU
+    bottleneck). Returns X unchanged when max_sequences is 0/disabled or n is already below it."""
+    if max_sequences and max_sequences > 0 and n > max_sequences:
+        rng = np.random.default_rng(RANDOM_STATE)
+        print(f"PCA fit-sample (CPU): {n} unique vectors > --max-sequences={max_sequences}; "
+              f"fitting on {max_sequences} sampled vectors, transforming all.")
+        return X[rng.choice(n, size=max_sequences, replace=False)]
+    return X
+
+
+def embedding_pca_reduce(X, args):
+    """Centered PCA → the 95%-variance component count (cap SVD_MAX_COMPONENTS); transform ALL rows.
+
+    Per-backend fit policy mirrors the sequence path exactly:
+      - GPU (cuML): fit on ALL unique rows, no cap — like run_gpu_pipeline (sequence GPU fits on all).
+      - CPU (sklearn): fit on a seeded --max-sequences sample — like run_cpu_pipeline, since dense
+        svd_solver='full' on all rows is a CPU bottleneck.
+    A GPU OOM/error falls back to the (fit-sampled).
+    Returns (Xr float32, k)."""
+    n, D = X.shape
+    cap = min(SVD_MAX_COMPONENTS, n - 1, D)
+    if cap < 1:
+        return X.astype(np.float32), D
+
+    if args.svd_backend in ('cuml', 'auto'):
+        try:
+            ncomp = min(cap, n - 1, D)   # GPU: fit on ALL unique rows (no cap)
+            return _pca_reduce_cuml(X, X, ncomp)
+        except Exception as e:  # noqa: BLE001 — OOM/import/CUDA all fall back to CPU
+            if args.svd_backend == 'cuml':
+                print(f"Error: cuML PCA failed and backend forced to 'cuml': {e}")
+                raise
+            print(f"cuML PCA unavailable or failed ({e}); falling back to CPU PCA (fit-sampled).")
+
+    # CPU: fit on a seeded --max-sequences sample (matches the sequence CPU path), transform all.
+    X_fit = _fit_sample(X, args.max_sequences, n)
+    ncomp = min(cap, X_fit.shape[0] - 1, D)
+    return _pca_reduce_sklearn(X_fit, X, ncomp)
+
+
+def run_embedding_umap(Xn, umap_model, run_type, args):
+    """Fit/transform UMAP on the reduced, L2-normalized matrix (already materialized — no per-chunk
+    feature recompute). GPU: single fit_transform on all rows. CPU: fit on a sub-sample
+    (UMAP_FIT_MAX_SAMPLE_SIZE), transform all rows. Default metric is Euclidean on both backends, which
+    on L2-normalized vectors is a monotonic function of cosine similarity. Returns (n, 2) coords."""
+    n = Xn.shape[0]
+    start = time.time()
+    if run_type == 'gpu':
+        try:
+            coords = np.asarray(umap_model.fit_transform(Xn))
+            print(f"UMAP (GPU) completed in {time.time() - start:.2f} seconds.\n")
+            return coords
+        except Exception as e:  # noqa: BLE001
+            print(f"Warning: GPU UMAP failed - {e}. Falling back to CPU UMAP...")
+            umap_model, run_type = create_umap_model(
+                'sklearn', args.umap_components, args.umap_neighbors, args.umap_min_dist)
+
+    np.random.seed(RANDOM_STATE)
+    if n > UMAP_FIT_MAX_SAMPLE_SIZE:
+        print(f"Fit sample ({n}) > {UMAP_FIT_MAX_SAMPLE_SIZE}. "
+              f"Sampling {UMAP_FIT_MAX_SAMPLE_SIZE} vectors for UMAP fitting.")
+        idx = np.random.choice(n, size=UMAP_FIT_MAX_SAMPLE_SIZE, replace=False)
+        umap_model.fit(Xn[idx])
+    else:
+        umap_model.fit(Xn)
+    coords = np.asarray(umap_model.transform(Xn))
+    print(f"UMAP (CPU) completed in {time.time() - start:.2f} seconds.\n")
+    return coords
+
+
+def _peak_rss_gib():
+    """Peak resident set size of this process, in GiB. ru_maxrss is in KB on Linux (where the block
+    software runs) and in bytes on macOS (local dev)."""
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == 'darwin':
+        return peak / (1024 ** 3)   # bytes -> GiB
+    return peak / (1024 ** 2)       # KB -> GiB
+
+
+def run_embedding_mode(args, output_path):
+    """Embedding feature path: load matrix → vector-dedup → centered PCA-95% → L2-normalize (eps-guarded,
+    degenerate rows excluded) → Euclidean UMAP → broadcast back to all clonotypes → write outputs.
+
+    Empty / too-few-rows inputs write an empty output and return (the k-mer path's guards are TSV/
+    sequence-specific, so embedding mode carries its own here). Clonotypes ABSENT from the embedding
+    column never enter this input, so they are simply absent from the output (sparse), like the k-mer
+    path's no-sequence drop — not the invalid-character null-coord path."""
+    print(f"Loading embedding matrix {args.matrix} ...")
+    X, keys = load_embedding_matrix(args.matrix, args.key_col, args.dim_col, args.value_col)
+    n_clonotypes = X.shape[0]
+    D = X.shape[1] if n_clonotypes else 0
+    print(f"Loaded {n_clonotypes} clonotypes x {D} embedding dims.")
+    print(f"Peak memory after matrix load: {_peak_rss_gib():.2f} GiB")
+
+    if n_clonotypes == 0:
+        print("Warning: Embedding matrix is empty — writing empty output.")
+        create_empty_umap_output(KEY_COL, args.umap_components, output_path)
+        create_empty_skipped_summary(args.output_dir,
+                                     "UMAP analysis skipped due to empty embedding matrix.")
+        return
+
+    min_required = max(args.umap_neighbors + 1, 4)
+
+    # Vector-dedup (exact, bit-identical for same-model embeddings): collapse identical rows before the
+    # fit, re-expand after via the inverse index.
+    uniq, inv = np.unique(X, axis=0, return_inverse=True)
+    inv = inv.ravel()
+    n_unique = uniq.shape[0]
+    if n_unique < n_clonotypes:
+        print(f"Deduplicating vectors: {n_clonotypes} → {n_unique} unique "
+              f"({n_clonotypes - n_unique} identical vectors collapsed for PCA/UMAP).")
+
+    if n_unique < min_required:
+        print(f"Warning: Not enough unique embedding vectors for UMAP "
+              f"(required {min_required}, unique {n_unique}) — writing empty output.")
+        create_empty_umap_output(KEY_COL, args.umap_components, output_path)
+        create_empty_skipped_summary(args.output_dir,
+                                     "UMAP analysis skipped due to insufficient unique vectors.")
+        return
+
+    # Centered PCA → 95% variance (cap 500). GPU fits on all unique rows (no cap, like the sequence
+    # GPU path); CPU fits on a seeded --max-sequences sample.
+    start_pca = time.time()
+    Xr, k_pca = embedding_pca_reduce(uniq, args)
+    print(f"Centered PCA: {uniq.shape[1]} → {k_pca} components (95% variance, cap "
+          f"{SVD_MAX_COMPONENTS}) in {time.time() - start_pca:.2f}s.")
+
+    # Degenerate (near-zero post-PCA residual) detection BEFORE normalization: such a vector sits at the
+    # dataset mean, so its normalized direction is numerical noise — exclude from the fit, null coords,
+    # count. The eps-guarded L2-normalize itself can't 0/0; Euclidean never NaNs from a zero row.
+    pre_norm = np.linalg.norm(Xr, axis=1)
+    valid = pre_norm > DEGENERATE_NORM_THRESHOLD
+    n_degenerate = int((~valid).sum())
+    if n_degenerate:
+        print(f"Warning: {n_degenerate} unique vector(s) near-zero norm post-PCA "
+              f"(centered-PCA residual ≈ dataset mean) — excluded from the UMAP fit, null coords.")
+    Xn = l2_normalize(Xr)
+
+    n_valid = int(valid.sum())
+    if n_valid < min_required:
+        print(f"Warning: Not enough non-degenerate vectors for UMAP "
+              f"(required {min_required}, valid {n_valid}) — writing empty output.")
+        create_empty_umap_output(KEY_COL, args.umap_components, output_path)
+        create_empty_skipped_summary(args.output_dir,
+                                     "UMAP analysis skipped due to insufficient non-degenerate vectors.")
+        return
+
+    umap_model, run_type = create_umap_model(
+        args.umap_backend, args.umap_components, args.umap_neighbors, args.umap_min_dist)
+
+    print(f"Running UMAP on {n_valid} non-degenerate unique vectors "
+          f"(L2-normalized, Euclidean ≡ cosine)...")
+    coords_valid = run_embedding_umap(Xn[valid], umap_model, run_type, args)
+
+    # Degenerate uniques get NaN coords; assemble the full unique-coord matrix, then broadcast to every
+    # clonotype via the dedup inverse index. NaN rows surface as null coords downstream.
+    coords_unique = np.full((n_unique, args.umap_components), np.nan, dtype=np.float64)
+    coords_unique[valid] = coords_valid
+    coords_all = coords_unique[inv]
+
+    print(f"Embedding UMAP summary: model={args.embedding_model or '(unknown)'}, mode=embedding, "
+          f"clonotypes={n_clonotypes}, unique={n_unique}, PCA k={k_pca}, "
+          f"degenerate-excluded={n_degenerate}")
+
+    write_embedding_outputs(args, keys, coords_all, output_path,
+                            n_clonotypes=n_clonotypes, n_unique=n_unique, k_pca=k_pca,
+                            n_degenerate=n_degenerate)
+
+    # Peak memory across the whole embedding run (matrix load + dedup + PCA + UMAP). Reported so the
+    # mem control can be sized to the actual N x D footprint, and to calibrate any backend cap.
+    print(f"Peak memory (RSS) for embedding run: {_peak_rss_gib():.2f} GiB "
+          f"(N={n_clonotypes}, unique={n_unique}, D={D}, PCA backend fit + UMAP).")
+
+
+def write_embedding_outputs(args, keys, coords_all, output_path, n_clonotypes, n_unique, k_pca,
+                            n_degenerate):
+    """Write the UMAP coordinates TSV (clonotypeKey, UMAP1, UMAP2, …) and the processing-log summary.
+
+    Degenerate rows carry NaN coordinates; NaN is converted to null so the TSV has empty cells (matching
+    the k-mer path's null coords for excluded sequences), not the literal string "NaN"."""
+    coord_dict = {KEY_COL: [str(k) for k in keys]}
+    for i in range(args.umap_components):
+        coord_dict[f'UMAP{i + 1}'] = coords_all[:, i].tolist()
+    df = pl.DataFrame(coord_dict)
+    df = df.with_columns([
+        pl.when(pl.col(f'UMAP{i + 1}').is_nan())
+          .then(None)
+          .otherwise(pl.col(f'UMAP{i + 1}'))
+          .alias(f'UMAP{i + 1}')
+        for i in range(args.umap_components)
+    ])
+    df.write_csv(output_path, separator='\t', null_value='')
+
+    # Saved as skipped_clonotypes_summary.txt to satisfy the exec's saveFile contract (shared with the
+    # k-mer path). Clonotypes absent from the embedding column never enter this input → they are absent
+    # from the output (sparse); that count is stated in the upstream embedding block.
+    summary_path = os.path.join(args.output_dir, 'skipped_clonotypes_summary.txt')
+    with open(summary_path, 'w') as f:
+        f.write("Embedding-mode UMAP summary\n")
+        f.write(f"Embedding model: {args.embedding_model or '(unknown)'}\n")
+        f.write(f"Clonotypes embedded: {n_clonotypes}\n")
+        f.write(f"Unique vectors (after dedup): {n_unique}\n")
+        f.write(f"PCA components (95% variance): {k_pca}\n")
+        f.write(f"Degenerate clonotypes excluded (null coords): {n_degenerate}\n")
+    print(f"Embedding UMAP summary saved to {summary_path}")
+
+
+# ============================================================================
 # Output writing
 # ============================================================================
 
@@ -992,22 +1326,41 @@ def main():
 
     os.makedirs(args.output_dir, exist_ok=True)
 
-    sequence_type = "amino acid" if args.alphabet == 'aminoacid' else "nucleotide"
-    max_seq_str = str(args.max_sequences) if args.max_sequences > 0 else "disabled"
-    print(f"Starting k-mer UMAP analysis for {sequence_type} sequences")
-    print(f"Input file: {args.input}")
-    print(f"Output file: {args.umap_output}")
-    print(f"Parameters: alphabet={args.alphabet}, k-mer size={args.k_mer_size}, "
-          f"UMAP components={args.umap_components}, "
-          f"UMAP neighbors={args.umap_neighbors}, "
-          f"UMAP min_dist={args.umap_min_dist}, "
-          f"SVD Backend={args.svd_backend.upper()}, "
-          f"UMAP Backend={args.umap_backend.upper()}, "
-          f"max-sequences={max_seq_str}")
+    # k-mer banner is sequence-specific; embedding mode prints its own banner in run_embedding_mode.
+    if args.encoding != 'embedding':
+        sequence_type = "amino acid" if args.alphabet == 'aminoacid' else "nucleotide"
+        max_seq_str = str(args.max_sequences) if args.max_sequences > 0 else "disabled"
+        print(f"Starting k-mer UMAP analysis for {sequence_type} sequences")
+        print(f"Input file: {args.input}")
+        print(f"Output file: {args.umap_output}")
+        print(f"Parameters: alphabet={args.alphabet}, k-mer size={args.k_mer_size}, "
+              f"UMAP components={args.umap_components}, "
+              f"UMAP neighbors={args.umap_neighbors}, "
+              f"UMAP min_dist={args.umap_min_dist}, "
+              f"SVD Backend={args.svd_backend.upper()}, "
+              f"UMAP Backend={args.umap_backend.upper()}, "
+              f"max-sequences={max_seq_str}")
 
     validate_args(args)
 
     output_path = os.path.join(args.output_dir, args.umap_output)
+
+    # Embedding feature path: read the parquet matrix and run centered PCA-95% →
+    # L2-normalize → Euclidean UMAP. Branches BEFORE load_and_filter_input, which is TSV/sequence-
+    # specific. Carries its own empty/min-rows guards inside run_embedding_mode.
+    if args.encoding == 'embedding':
+        if not args.matrix:
+            print("Error: --encoding embedding requires --matrix (the embedding parquet file).")
+            sys.exit(1)
+        print("Embedding feature mode: running UMAP on learned embedding vectors.")
+        start_time_emb = time.time()
+        run_embedding_mode(args, output_path)
+        print(f"\nTotal analysis completed in {time.time() - start_time_emb:.2f} seconds.")
+        return
+
+    if not args.input:
+        print("Error: -i/--input is required for kmer/pos-kmer encodings.")
+        sys.exit(1)
 
     start_time_load = time.time()
     df, df_valid, df_invalid, n_invalid = load_and_filter_input(args, output_path)

--- a/ui/src/pages/UmapPage.vue
+++ b/ui/src/pages/UmapPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { getDefaultBlockLabel } from '@platforma-open/milaboratories.clonotype-space.model';
 import type {
   PColumnIdAndSpec,
   PlRef,
@@ -6,7 +7,6 @@ import type {
   SUniversalPColumnId,
 } from '@platforma-sdk/model';
 import { getRawPlatformaInstance } from '@platforma-sdk/model';
-import { getDefaultBlockLabel } from '@platforma-open/milaboratories.clonotype-space.model';
 
 import { PlMultiSequenceAlignment } from '@milaboratories/multi-sequence-alignment';
 import strings from '@milaboratories/strings';
@@ -47,11 +47,19 @@ const filteredSequenceOptions = computed(() => {
 });
 
 const defaultLabel = computed(() =>
-  getDefaultBlockLabel({
-    sequenceLabels: app.model.data.sequenceLabels,
-    umap_neighbors: app.model.data.umap_neighbors,
-    umap_min_dist: app.model.data.umap_min_dist,
-  }),
+  app.model.data.inputMode === 'embedding'
+    ? getDefaultBlockLabel({
+        inputMode: 'embedding',
+        embeddingLabel: app.model.data.selectedEmbeddingLabel ?? '',
+        umap_neighbors: app.model.data.umap_neighbors,
+        umap_min_dist: app.model.data.umap_min_dist,
+      })
+    : getDefaultBlockLabel({
+        inputMode: 'sequence-features',
+        sequenceLabels: app.model.data.sequenceLabels,
+        umap_neighbors: app.model.data.umap_neighbors,
+        umap_min_dist: app.model.data.umap_min_dist,
+      }),
 );
 
 // Snapshot labels for the chosen sequenceRefs from current options. V3 keeps
@@ -73,6 +81,12 @@ const inputAnchorModel = computed({
     // new dataset's defaults.
     app.model.data.sequencesRef = [];
     app.model.data.sequenceLabels = [];
+    // Embedding refs are anchor-bound and not portable across datasets: reset to sequence mode and
+    // clear the embedding selection on any dataset change. The embedding
+    // auto-select watcher below then reseeds embeddingRef from the new dataset's options.
+    app.model.data.inputMode = 'sequence-features';
+    app.model.data.embeddingRef = undefined;
+    app.model.data.selectedEmbeddingLabel = '';
   },
 });
 
@@ -87,6 +101,101 @@ const sequencesRefModel = computed({
 function setSequencesRef(refs: SUniversalPColumnId[]) {
   sequencesRefModel.value = refs;
 }
+
+// --- Embedding input mode ---
+const inputModeOptions = [
+  { label: 'Sequences', value: 'sequence-features' },
+  { label: 'Embeddings', value: 'embedding' },
+] as const;
+
+// Embedding mode is reachable only when an embedding column is discoverable on the dataset.
+const embeddingAvailable = computed(() => (app.model.outputs.embeddingOptions?.length ?? 0) > 0);
+// Effective mode: render sequence controls if embeddings aren't available, even if the stored mode
+// is 'embedding' (e.g. embeddings vanished without a dataset change), so the UI and args agree.
+const effectiveMode = computed(() =>
+  (app.model.data.inputMode === 'embedding' && embeddingAvailable.value) ? 'embedding' : 'sequence-features',
+);
+
+type EmbeddingOption = NonNullable<typeof app.model.outputs.embeddingOptions>[number];
+
+// Feature priority for the most-complete auto-select: the `pl7.app/feature` DOMAIN values the
+// producer emits
+const FEATURE_PRIORITY = ['Fv', 'scFv', 'VDJRegion', 'CDR3', 'peptide'];
+
+function pickMostCompleteEmbedding(options: EmbeddingOption[]): EmbeddingOption | undefined {
+  if (options.length === 0) return undefined;
+  const rank = (f?: string) => {
+    const i = FEATURE_PRIORITY.indexOf(f ?? '');
+    return i === -1 ? FEATURE_PRIORITY.length : i;
+  };
+  return [...options].sort((a, b) => {
+    const ra = rank(a.feature);
+    const rb = rank(b.feature);
+    if (ra !== rb) return ra - rb;
+    // Per-chain tie (single-cell paired inputs expose two columns at one feature): prefer chain A
+    // (heavy / α / γ). Bulk inputs are single-chain (chain on the input axis), so no tie arises.
+    const ca = a.chain === 'A' ? 0 : 1;
+    const cb = b.chain === 'A' ? 0 : 1;
+    if (ca !== cb) return ca - cb;
+    // Deterministic fallback (stable across multi-client instances).
+    return (a.label ?? '').localeCompare(b.label ?? '');
+  })[0];
+}
+
+function labelForEmbeddingRef(ref: PlRef): string {
+  const opts = app.model.outputs.embeddingOptions;
+  return opts?.find((o) => o.ref.blockId === ref.blockId && o.ref.name === ref.name)?.label ?? '';
+}
+
+// Mode toggle gesture (V3 gesture-driven write, NOT a watcher).
+function onModeChange(mode: 'sequence-features' | 'embedding') {
+  app.model.data.inputMode = mode;
+}
+
+// On embedding-column pick: store the ref and snapshot its native label for the subtitle (V3
+// gesture-driven write
+function onEmbeddingRefChange(ref?: PlRef) {
+  app.model.data.embeddingRef = ref;
+  app.model.data.selectedEmbeddingLabel = ref ? labelForEmbeddingRef(ref) : '';
+}
+
+// Safeguard: if the embedding column's producer becomes undiscoverable while embedding mode is stored
+// (e.g. the upstream Sequence Embeddings block is removed without a dataset change), fall back to
+// sequence mode
+watch(embeddingAvailable, (available) => {
+  if (!available && app.model.data.inputMode === 'embedding') {
+    app.model.data.inputMode = 'sequence-features';
+    app.model.data.embeddingRef = undefined;
+    app.model.data.selectedEmbeddingLabel = '';
+  }
+});
+
+// Auto-select the most-complete embedding column whenever the current selection is empty or no longer
+// matches the discoverable options. Reseeded on dataset change (inputAnchorModel clears
+// embeddingRef); an explicit user pick is preserved while it stays valid.
+watch(
+  () => app.model.outputs.embeddingOptions,
+  (options) => {
+    if (!options || options.length === 0) return;
+    const current = app.model.data.embeddingRef;
+    const stillValid = !!current
+      && options.some((o) => o.ref.blockId === current.blockId && o.ref.name === current.name);
+    if (stillValid) {
+      // Keep the selection; reseed the label snapshot if it drifted (e.g. a legacy load had none).
+      const label = labelForEmbeddingRef(current);
+      if (label && app.model.data.selectedEmbeddingLabel !== label) {
+        app.model.data.selectedEmbeddingLabel = label;
+      }
+      return;
+    }
+    const best = pickMostCompleteEmbedding(options);
+    if (best) {
+      app.model.data.embeddingRef = best.ref;
+      app.model.data.selectedEmbeddingLabel = best.label ?? '';
+    }
+  },
+  { immediate: true },
+);
 
 const defaultOptions = computed((): PredefinedGraphOption<'scatterplot-umap'>[] | null => {
   const umapPcols = app.model.outputs.umapPcols;
@@ -216,6 +325,24 @@ watch(
           :style="{ width: '320px' }"
         />
 
+        <PlBtnGroup
+          v-if="embeddingAvailable"
+          :model-value="app.model.data.inputMode"
+          label="UMAP mode"
+          :options="inputModeOptions"
+          :compact="true"
+          :style="{ width: '320px' }"
+          @update:model-value="onModeChange"
+        >
+          <template #tooltip>
+            <div>
+              Choose the features UMAP lays out:<br><br>
+              <strong>Sequences</strong> — Reflects letter-level similarity.<br><br>
+              <strong>Embeddings</strong> — Reflects learned biochemical and structural similarity.
+            </div>
+          </template>
+        </PlBtnGroup>
+
         <PlTextField
           v-model="app.model.data.customBlockLabel"
           label="Block title"
@@ -226,16 +353,26 @@ watch(
 
         <PlAccordionSection label="UMAP Parameters" :style="{ width: '320px' }">
           <PlBtnGroup
+            v-if="effectiveMode === 'sequence-features'"
             v-model="app.model.data.sequenceType"
             label="Sequence type"
             :options="sequenceType"
             :compact="true"
           />
           <PlDropdownMulti
+            v-if="effectiveMode === 'sequence-features'"
             v-model="sequencesRefModel"
             :options="filteredSequenceOptions"
-            label="Select sequence column/s for UMAP"
+            label="Select sequence/s for UMAP"
             required
+          />
+          <PlDropdownRef
+            v-if="effectiveMode === 'embedding'"
+            :model-value="app.model.data.embeddingRef"
+            :options="app.model.outputs.embeddingOptions"
+            label="Select Embedding for UMAP"
+            required
+            @update:model-value="onEmbeddingRefChange"
           />
 
           <div :style="{ display: 'flex', gap: '8px', width: '320px' }">

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -1,25 +1,45 @@
 // Clonotype space workflow.
 //
-// The outer body runs immediately (no `wf.prepare`) so that exports — and therefore
-// output specs — are defined as soon as possible. The inner `process` template awaits
-// only the PColumnBundle's specs (not its data), enabling early spec export to the
-// result pool. Downstream blocks can configure their inputs while UMAP is still
-// computing.
+// The outer body delegates to the inner `process` template, which awaits only the PColumnBundle's
+// specs (not its data), so exports — and therefore output specs — are published to the result pool as
+// early as possible. Downstream blocks can configure their inputs while UMAP is still computing.
+//
+// Embedding mode adds a `wf.prepare` that resolves the embedding `PlRef` (only when set).
 
 wf := import("@platforma-sdk/workflow-tengo:workflow")
 assets := import("@platforma-sdk/workflow-tengo:assets")
 render := import("@platforma-sdk/workflow-tengo:render")
 pframes := import("@platforma-sdk/workflow-tengo:pframes")
+xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 
 processTpl := assets.importTemplate(":process")
 
+wf.prepare(func(args) {
+	// Resolve the selected embedding column as an explicit input (embedding mode only). This wires its
+	// separate sequence-embeddings producer in as an upstream and pulls the matrix.
+	//
+	// Only add the key when it has a value
+	prepared := {}
+	if !is_undefined(args.embeddingRef) {
+		prepared.resolvedEmbedding = wf.resolve(args.embeddingRef, { errIfMissing: true })
+	}
+
+	return prepared
+})
+
 wf.body(func(args) {
-	// Build PColumn bundle (deferred — resolves asynchronously).
+	inputMode := is_undefined(args.inputMode) ? "sequence-features" : args.inputMode
+	// In embedding mode the args lambda omits sequencesRef (V3 conditional suppression); guard so the
+	// bundle build below iterates an empty list rather than `undefined`.
+	sequencesRef := is_undefined(args.sequencesRef) ? [] : args.sequencesRef
+
+	// Build PColumn bundle (deferred — resolves asynchronously). Provides the dataset spec (output axis
+	// + trace) in both modes; sequence columns are added only in sequence mode.
 	bundleBuilder := wf.createPBundleBuilder()
 	bundleBuilder.ignoreMissingDomains() // make query work for both bulk and single cell data
 	bundleBuilder.addAnchor("main", args.inputAnchor)
 
-	for ref in args.sequencesRef {
+	for ref in sequencesRef {
 		bundleBuilder.addSingle(ref)
 	}
 
@@ -33,20 +53,57 @@ wf.body(func(args) {
 
 	columns := bundleBuilder.build()
 
-	// Delegate to the inner template. Its body runs as soon as upstream specs are
-	// available — does not wait for upstream data.
-	processResult := render.createEphemeral(processTpl, {
+	// Inputs shared by both modes.
+	processInputs := {
 		columns: columns,
 		blockId: wf.blockId().getDataAsJson(),
 		inputAnchor: args.inputAnchor,
-		sequencesRef: args.sequencesRef,
-		sequenceType: args.sequenceType,
+		inputMode: inputMode,
 		umap_neighbors: args.umap_neighbors,
 		umap_min_dist: args.umap_min_dist,
 		customBlockLabel: args.customBlockLabel,
-		defaultBlockLabel: args.defaultBlockLabel,
-		mem: args.mem,
-		cpu: args.cpu
+		defaultBlockLabel: args.defaultBlockLabel
+	}
+
+	if inputMode == "embedding" {
+		// Embedding column resolved in prepare.
+		embeddingCol := args.resolvedEmbedding
+		embSpec := embeddingCol.spec
+		// Model provenance from the column's spec (stamped on the output domain).
+		embeddingModel := embSpec.domain["pl7.app/embedding/model"]
+
+		// Long-format Parquet matrix
+		embeddingMatrix := xsv.exportFrame([embeddingCol], "parquet", {
+			mem: string(args.mem) + "GiB",
+			cpu: 4
+		})
+
+		// Matrix column headers are the embedding column's own axis/value pl7.app/label values, passed
+		// to main.py as --key-col/--dim-col/--value-col. The clonotype axis passes through verbatim from
+		// the dataset and may lack a pl7.app/label, so fall back to "clonotypeKey" — keeps the parquet
+		// header and --key-col in agreement.
+		keyCol := embSpec.axesSpec[0].annotations["pl7.app/label"]
+		if is_undefined(keyCol) {
+			keyCol = "clonotypeKey"
+		}
+
+		processInputs.embeddingMatrix = embeddingMatrix
+		processInputs.embeddingModel = embeddingModel
+		processInputs.keyCol = keyCol
+		processInputs.dimCol = embSpec.axesSpec[1].annotations["pl7.app/label"]
+		processInputs.valueCol = embSpec.annotations["pl7.app/label"]
+	} else {
+		processInputs.sequencesRef = sequencesRef
+		processInputs.sequenceType = args.sequenceType
+	}
+
+	// Delegate to the inner template. Its body runs as soon as upstream specs are available — does not
+	// wait for upstream data.
+	processResult := render.createEphemeral(processTpl, processInputs, {
+		metaInputs: {
+			mem: args.mem,
+			cpu: args.cpu
+		}
 	})
 
 	pfRef := processResult.output("pf")

--- a/workflow/src/pf-umap-conv.lib.tengo
+++ b/workflow/src/pf-umap-conv.lib.tengo
@@ -1,6 +1,20 @@
 ll := import("@platforma-sdk/workflow-tengo:ll")
 
-getColumns := func(datasetSpec, blockId) {
+// Build the umap1/umap2 output domain. In embedding mode (embeddingModel set) the 
+// embedding-derived projection is distinguishable and traceable in the result
+// pool. In sequence mode (embeddingModel undefined) the domain is column identity,
+// so the k-mer columns must NOT change.
+buildUmapDomain := func(blockId, embeddingModel) {
+  d := {
+    "pl7.app/umap/blockId": blockId
+  }
+  if !is_undefined(embeddingModel) {
+    d["pl7.app/embedding/model"] = embeddingModel
+  }
+  return d
+}
+
+getColumns := func(datasetSpec, blockId, embeddingModel) {
   return {
     axes: [
       {
@@ -16,9 +30,7 @@ getColumns := func(datasetSpec, blockId) {
         spec: {
           name: "pl7.app/umap1",
           valueType: "Double",
-          domain: {
-            "pl7.app/umap/blockId": blockId
-          },
+          domain: buildUmapDomain(blockId, embeddingModel),
           annotations: {
             "pl7.app/label": "UMAP Dim1",
             "pl7.app/format": ".2f",
@@ -33,9 +45,7 @@ getColumns := func(datasetSpec, blockId) {
         spec: {
           name: "pl7.app/umap2",
           valueType: "Double",
-          domain: {
-            "pl7.app/umap/blockId": blockId
-          },
+          domain: buildUmapDomain(blockId, embeddingModel),
           annotations: {
             "pl7.app/label": "UMAP Dim2",
             "pl7.app/format": ".2f",

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -2,8 +2,12 @@
 //
 // Awaits only the PColumnBundle specs (not data), so the body runs — and the output
 // PFrame's specs are published — before upstream column data is computed. The data
-// pipeline (TSV build → UMAP exec → xsv import) is deferred and resolves when its
+// pipeline (TSV/matrix build → UMAP exec → xsv import) is deferred and resolves when its
 // inputs become available.
+//
+// Dispatches on inputMode: 'sequence-features' builds the k-mer TSV and runs the
+// k-mer → SVD → UMAP path; 'embedding' routes the exported Parquet matrix through main.py's
+// embedding feature path and stamps the embedding model on the output domain.
 
 self := import("@platforma-sdk/workflow-tengo:tpl")
 assets := import("@platforma-sdk/workflow-tengo:assets")
@@ -24,8 +28,7 @@ self.body(func(inputs) {
 	columns := inputs.columns
 	blockId := inputs.blockId
 	inputAnchor := inputs.inputAnchor
-	sequencesRef := inputs.sequencesRef
-	alphabet := inputs.sequenceType
+	inputMode := is_undefined(inputs.inputMode) ? "sequence-features" : inputs.inputMode
 	umap_neighbors := inputs.umap_neighbors
 	umap_min_dist := inputs.umap_min_dist
 	customBlockLabel := inputs.customBlockLabel
@@ -40,58 +43,89 @@ self.body(func(inputs) {
 	// Spec is plain JSON, available now (PColumnBundle await covered specs).
 	datasetSpec := columns.getSpec(inputAnchor)
 
-	// compute the shortest peptide length
-	isPeptide := datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
-	minPeptideLength := undefined
-	if isPeptide {
-		peptideLenCols := columns.getColumns("peptideSequenceLength")
-		if len(peptideLenCols) > 0 {
-			minLenResult := render.create(minPeptideLengthTpl, {
-				spec: peptideLenCols[0].spec,
-				data: peptideLenCols[0].data
-			})
-			minPeptideLength = minLenResult.output("minLength")
-		} else {
-			ll.panic("Peptide input is missing required pl7.app/sequenceLength column")
+	// Embedding model: undefined in sequence mode.
+	embeddingModel := undefined
+	umapRender := undefined
+
+	if inputMode == "embedding" {
+		embeddingModel = inputs.embeddingModel
+
+		// Run the embedding UMAP path.
+		umapRender = render.create(umapCalculationTpl, {
+			inputMode: "embedding",
+			embeddingMatrix: inputs.embeddingMatrix,
+			embeddingModel: embeddingModel,
+			keyCol: inputs.keyCol,
+			dimCol: inputs.dimCol,
+			valueCol: inputs.valueCol,
+			umap_neighbors: umap_neighbors,
+			umap_min_dist: umap_min_dist
+		}, {
+			metaInputs: {
+				mem: mem,
+				cpu: cpu
+			}
+		})
+	} else {
+		alphabet := inputs.sequenceType
+		sequencesRef := inputs.sequencesRef
+
+		// compute the shortest peptide length
+		isPeptide := datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
+		minPeptideLength := undefined
+		if isPeptide {
+			peptideLenCols := columns.getColumns("peptideSequenceLength")
+			if len(peptideLenCols) > 0 {
+				minLenResult := render.create(minPeptideLengthTpl, {
+					spec: peptideLenCols[0].spec,
+					data: peptideLenCols[0].data
+				})
+				minPeptideLength = minLenResult.output("minLength")
+			} else {
+				ll.panic("Peptide input is missing required pl7.app/sequenceLength column")
+			}
 		}
+
+		// Build input TSV with clonotype id and selected sequence columns.
+		// Column data is a deferred reference here — the TSV builder consumes it lazily.
+		umapTable := pframes.tsvFileBuilder()
+		umapTable.setAxisHeader(datasetSpec.axesSpec[1].name, "clonotypeKey")
+		for nr, seqRef in sequencesRef {
+			seq := columns.getColumn(seqRef)
+			umapTable.add(seq, {header: "sequence_" + string(nr)})
+		}
+		umapTable.mem("16GiB") // TODO: make this dynamic on input size
+		umapTable.cpu(1)
+		umapTable = umapTable.build()
+
+		// Run the UMAP exec template (deferred — its inputs await the TSV above).
+		// mem/cpu are passed via metaInputs so changes to them do not retrigger the umap template.
+		umapRender = render.create(umapCalculationTpl, {
+			inputMode: "sequence-features",
+			umapTable: umapTable,
+			umap_neighbors: umap_neighbors,
+			umap_min_dist: umap_min_dist,
+			alphabet: alphabet,
+			isPeptide: isPeptide,
+			minPeptideLength: minPeptideLength
+		}, {
+			metaInputs: {
+				mem: mem,
+				cpu: cpu
+			}
+		})
 	}
 
-	// Build input TSV with clonotype id and selected sequence columns.
-	// Column data is a deferred reference here — the TSV builder consumes it lazily.
-	umapTable := pframes.tsvFileBuilder()
-	umapTable.setAxisHeader(datasetSpec.axesSpec[1].name, "clonotypeKey")
-	for nr, seqRef in sequencesRef {
-		seq := columns.getColumn(seqRef)
-		umapTable.add(seq, {header: "sequence_" + string(nr)})
-	}
-	umapTable.mem("16GiB") // TODO: make this dynamic on input size
-	umapTable.cpu(1)
-	umapTable = umapTable.build()
-
-	// Run the UMAP exec template (deferred — its inputs await the TSV above).
-	// mem/cpu are passed via metaInputs so changes to them do not retrigger the umap template.
-	umapRender := render.create(umapCalculationTpl, {
-		umapTable: umapTable,
-		umap_neighbors: umap_neighbors,
-		umap_min_dist: umap_min_dist,
-		alphabet: alphabet,
-		isPeptide: isPeptide,
-		minPeptideLength: minPeptideLength
-	}, {
-		metaInputs: {
-			mem: mem,
-			cpu: cpu
-		}
-	})
 	umapTsVFile := umapRender.output("umapTsVFile")
 	umapOutput := umapRender.output("umapOutput")
 
 	// Import UMAP results to PFrame. `splitDataAndSpec: true` gives us specs (immediate
-	// JSON, derived from the import config) and deferred data references.
+	// JSON, derived from the import config) and deferred data references. In embedding mode the
+	// embedding model is merged into the umap1/umap2 domain; undefined otherwise.
 	umapPf := xsv.importFile(
 		umapTsVFile,
 		"tsv",
-		umapConv.getColumns(datasetSpec, blockId),
+		umapConv.getColumns(datasetSpec, blockId, embeddingModel),
 		{
 			splitDataAndSpec: true,
 			cpu: 1,

--- a/workflow/src/umap-calculation.tpl.tengo
+++ b/workflow/src/umap-calculation.tpl.tengo
@@ -8,49 +8,76 @@ json := import("json")
 self.defineOutputs("umapTsVFile", "umapOutput")
 
 self.body(func(args) {
-    // Input parameters
-    umapTable := args.umapTable
+    // Input parameters (shared)
     umap_neighbors := args.umap_neighbors
     umap_min_dist := args.umap_min_dist
-    alphabet := args.alphabet
     mem := args.mem
     cpu := args.cpu
+    inputMode := is_undefined(args.inputMode) ? "sequence-features" : args.inputMode
 
-    // Calculate k-mer size based on alphabet
-    kmerSize := 3 // default for aminoacid
-    if alphabet == "nucleotide" {
-        kmerSize = 6
-    }
-    encoding := "kmer"
+    builder := exec.builder().
+        software(assets.importSoftware("@platforma-open/milaboratories.clonotype-space.umap:main")).
+        mem(string(mem) + "GiB").
+        cpu(cpu)
 
-    // Short-peptide override: when the input is peptide-mode AND the shortest
-    // peptide is below 10 aa
-    isPeptide := is_undefined(args.isPeptide) ? false : args.isPeptide
-    if isPeptide && !is_undefined(args.minPeptideLength) {
-        minLen := int(json.decode(string(args.minPeptideLength.getData())).min_len)
-        if minLen < 10 {
-            kmerSize = 2
-            encoding = "pos-kmer"
+    if inputMode == "embedding" {
+        // Embedding feature path: main.py reads the exported Parquet matrix instead of counting k-mers
+        // (--encoding embedding), then runs centered PCA-95% -> L2-normalize -> Euclidean UMAP.
+        builder = builder.
+            addFile("embedding.parquet", args.embeddingMatrix).
+            arg("--encoding").arg("embedding").
+            arg("--matrix").arg("embedding.parquet").
+            arg("--key-col").arg(args.keyCol).
+            arg("--dim-col").arg(args.dimCol).
+            arg("--value-col").arg(args.valueCol).
+            arg("-u").arg("umap.tsv").
+            arg("--umap-neighbors").arg(string(umap_neighbors)).
+            arg("--umap-min-dist").arg(string(umap_min_dist)).
+            arg("--n-jobs").arg(string(cpu))
+
+        // Embedding model: logged to the processing log for provenance. Undefined if the column
+        // lacks the domain key — omit the flag rather than pass an empty string.
+        if !is_undefined(args.embeddingModel) {
+            builder = builder.arg("--embedding-model").arg(args.embeddingModel)
         }
+    } else {
+        alphabet := args.alphabet
+
+        // Calculate k-mer size based on alphabet
+        kmerSize := 3 // default for aminoacid
+        if alphabet == "nucleotide" {
+            kmerSize = 6
+        }
+        encoding := "kmer"
+
+        // Short-peptide override: when the input is peptide-mode AND the shortest
+        // peptide is below 10 aa
+        isPeptide := is_undefined(args.isPeptide) ? false : args.isPeptide
+        if isPeptide && !is_undefined(args.minPeptideLength) {
+            minLen := int(json.decode(string(args.minPeptideLength.getData())).min_len)
+            if minLen < 10 {
+                kmerSize = 2
+                encoding = "pos-kmer"
+            }
+        }
+
+        // Note: --seq-col-start "sequence" will match all columns starting with "sequence"
+        // (sequence.TRA, sequence.TRB, sequence_0, etc.)
+        builder = builder.
+            addFile("sequences.tsv", args.umapTable).
+            arg("-i").arg("sequences.tsv").
+            arg("-c").arg("sequence").
+            arg("-u").arg("umap.tsv").
+            arg("--umap-neighbors").arg(string(umap_neighbors)).
+            arg("--umap-min-dist").arg(string(umap_min_dist)).
+            arg("--alphabet").arg(alphabet).
+            arg("--k-mer-size").arg(string(kmerSize)).
+            arg("--encoding").arg(encoding).
+            arg("--n-jobs").arg(string(cpu))
     }
 
     // UMAP software execution
-    // Note: --seq-col-start "sequence" will match all columns starting with "sequence"
-    // (sequence.TRA, sequence.TRB, sequence_0, etc.)
-    umapClones := exec.builder().
-        software(assets.importSoftware("@platforma-open/milaboratories.clonotype-space.umap:main")).
-        mem(string(mem) + "GiB").
-        cpu(cpu).
-        addFile("sequences.tsv", umapTable).
-        arg("-i").arg("sequences.tsv").
-        arg("-c").arg("sequence").
-        arg("-u").arg("umap.tsv").
-        arg("--umap-neighbors").arg(string(umap_neighbors)).
-        arg("--umap-min-dist").arg(string(umap_min_dist)).
-        arg("--alphabet").arg(alphabet).
-        arg("--k-mer-size").arg(string(kmerSize)).
-        arg("--encoding").arg(encoding).
-        arg("--n-jobs").arg(string(cpu)).
+    umapClones := builder.
         saveFile("umap.tsv").
         saveFile("skipped_clonotypes_summary.txt").
         saveStdoutStream().
@@ -67,4 +94,3 @@ self.body(func(args) {
         umapOutput: umapOutput
     }
 })
-


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an **embedding mode** to the clonotype-space UMAP block, allowing UMAP projection to be driven by pre-computed per-clonotype embedding vectors (e.g. from an ESM-2 language model) instead of k-mer sequence features. The change touches every layer — model types, workflow templates, Python compute, and the Vue UI.

- **Model layer** (`types.ts`, `dataModel.ts`, `index.ts`): introduces `InputMode` (`'sequence-features' | 'embedding'`), the new `embeddingRef` / `selectedEmbeddingLabel` fields, a new `embeddingOptions` result-pool output, and conditional `BlockArgs` field suppression so stale off-mode values are never forwarded to the workflow.
- **Python compute** (`main.py`): adds a full embedding feature path — long-format parquet load via scatter-indexing, exact vector dedup, centered PCA-95%, degenerate-vector exclusion, L2-normalise, Euclidean UMAP (≡ cosine ranking), with CPU/GPU backends and fallback mirroring the existing k-mer path.
- **Workflow & UI** (`main.tpl.tengo`, `process.tpl.tengo`, `umap-calculation.tpl.tengo`, `UmapPage.vue`): embedding column is resolved via `wf.prepare`, exported to parquet, and routed through the new `--encoding embedding` CLI path; the UI shows a mode-toggle button only when compatible embedding columns are discoverable, with auto-select and safeguard watchers for column availability changes.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The embedding path is a well-structured addition, but two runtime failures are possible before the Python script can do useful work: the dimension column may arrive as float dtype causing a numpy indexing crash, and dimCol/valueCol may be silently passed as undefined strings if an embedding producer omits label annotations.

The model, UI, and workflow Tengo layers are solid. The Python embedding path has careful guards for empty inputs, degenerate vectors, and PCA/UMAP sub-sampling. However, load_embedding_matrix uses dims directly as numpy fancy-index without casting to integer — a float-typed parquet column from a non-standard producer would raise IndexError at scatter time. Separately, main.tpl.tengo passes dimCol and valueCol without fallbacks, unlike the explicitly documented keyCol guard, so a missing pl7.app/label annotation on the embedding's dimension axis would produce a confusing wrong-column-name error in Python. Both issues are on the critical hot path of the new embedding mode.

software/umap/src/main.py (integer cast for dims) and workflow/src/main.tpl.tengo (undefined fallbacks for dimCol/valueCol) need attention before the embedding path can be considered production-ready.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/types.ts | Adds InputMode discriminated union type and extends BlockData/BlockArgs with inputMode, embeddingRef, and selectedEmbeddingLabel; sequencesRef/sequenceType become optional in BlockArgs for conditional suppression in embedding mode. |
| model/src/dataModel.ts | Initialises new fields (inputMode, embeddingRef, selectedEmbeddingLabel) in both init() and upgradeLegacy(); defaults inputMode to 'sequence-features' so existing projects migrate cleanly. |
| model/src/index.ts | Adds embeddingOptions output querying result pool for compatible pl7.app/embedding columns; computeDefaultLabel and .args() now branch on inputMode with correct V3 conditional field suppression. |
| model/src/label.ts | Refactors getDefaultBlockLabel into a discriminated-union overload; embedding mode produces '<label> UMAP', sequence mode keeps existing label-joining behaviour. |
| software/umap/src/main.py | Adds the full embedding UMAP path (load parquet → vector dedup → centered PCA-95% → L2-normalise → Euclidean UMAP); two issues: dims lacks an explicit integer cast before fancy-indexing, and the CPU fit-sample uses legacy np.random.seed instead of np.random.default_rng. |
| workflow/src/main.tpl.tengo | Adds wf.prepare to resolve the embedding PlRef; dispatches mode-specific inputs to the process template; dimCol and valueCol lack the same undefined fallback that keyCol has, risking silent wrong column names in Python. |
| workflow/src/process.tpl.tengo | Refactors the process template to dispatch on inputMode; sequence-mode path is preserved verbatim inside the else branch; embedding mode passes pre-exported parquet to umap-calculation. |
| workflow/src/umap-calculation.tpl.tengo | Refactors the exec builder to dispatch on inputMode; embedding branch passes parquet flags, sequence branch keeps k-mer flags; shared saveFile/saveStdoutStream calls after the if/else are correct. |
| workflow/src/pf-umap-conv.lib.tengo | Introduces buildUmapDomain helper that conditionally stamps pl7.app/embedding/model on the umap1/umap2 output domain in embedding mode; sequence-mode domain is unchanged. |
| ui/src/pages/UmapPage.vue | Adds mode-toggle UI, embedding picker, auto-select watcher, and safeguard watcher; effectiveMode computed correctly falls back to sequence-features when embeddings vanish; dataset-change resets embedding selection appropriately. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[UI: inputMode toggle] -->|sequence-features| B[BlockArgs: sequencesRef + sequenceType]
    A -->|embedding| C[BlockArgs: embeddingRef]

    B --> D[main.tpl.tengo: wf.body]
    C --> E[main.tpl.tengo: wf.prepare resolves PlRef]
    E --> D

    D -->|sequence mode| F[process.tpl.tengo: build TSV]
    D -->|embedding mode| G[process.tpl.tengo: xsv.exportFrame → parquet]

    F --> H[umap-calculation.tpl.tengo: --encoding kmer/pos-kmer]
    G --> I[umap-calculation.tpl.tengo: --encoding embedding]

    H --> J[main.py: k-mer → SVD → UMAP]
    I --> K[main.py: load parquet → dedup → centered PCA-95% → L2-norm → UMAP]

    J --> L[pf-umap-conv: getColumns blockId only]
    K --> M[pf-umap-conv: getColumns blockId + embeddingModel]

    L --> N[Result pool: umap1/umap2 PColumns]
    M --> N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[UI: inputMode toggle] -->|sequence-features| B[BlockArgs: sequencesRef + sequenceType]
    A -->|embedding| C[BlockArgs: embeddingRef]

    B --> D[main.tpl.tengo: wf.body]
    C --> E[main.tpl.tengo: wf.prepare resolves PlRef]
    E --> D

    D -->|sequence mode| F[process.tpl.tengo: build TSV]
    D -->|embedding mode| G[process.tpl.tengo: xsv.exportFrame → parquet]

    F --> H[umap-calculation.tpl.tengo: --encoding kmer/pos-kmer]
    G --> I[umap-calculation.tpl.tengo: --encoding embedding]

    H --> J[main.py: k-mer → SVD → UMAP]
    I --> K[main.py: load parquet → dedup → centered PCA-95% → L2-norm → UMAP]

    J --> L[pf-umap-conv: getColumns blockId only]
    K --> M[pf-umap-conv: getColumns blockId + embeddingModel]

    L --> N[Result pool: umap1/umap2 PColumns]
    M --> N
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aworkflow%2Fsrc%2Fmain.tpl.tengo%3A93-94%0A**Missing%20fallbacks%20for%20%60dimCol%60%20and%20%60valueCol%60**%0A%0A%60keyCol%60%20gets%20a%20documented%20fallback%20to%20%60%22clonotypeKey%22%60%20when%20the%20annotation%20is%20absent%2C%20but%20%60dimCol%60%20and%20%60valueCol%60%20have%20no%20such%20guard.%20If%20an%20embedding%20column's%20second%20axis%20or%20the%20value%20annotation%20lacks%20%60pl7.app%2Flabel%60%2C%20both%20fields%20resolve%20to%20%60undefined%60%20in%20Tengo.%20Depending%20on%20how%20the%20workflow%20SDK%20serialises%20%60undefined%60%20to%20a%20CLI%20arg%2C%20the%20Python%20script%20will%20either%20receive%20the%20literal%20string%20%60%22undefined%22%60%20as%20the%20column%20name%20%28causing%20polars%20to%20error%20with%20a%20confusing%20%22column%20not%20found%22%29%20or%20will%20throw%20at%20template%20evaluation%20time.%20The%20%60keyCol%60%20comment%20explicitly%20calls%20out%20the%20dataset-axis%20label-absence%20risk%2C%20suggesting%20this%20pattern%20is%20known%20and%20the%20same%20defensive%20treatment%20should%20be%20applied%20here.%0A%0A%23%23%23%20Issue%202%20of%203%0Asoftware%2Fumap%2Fsrc%2Fmain.py%3A1012%0A**%60dims%60%20used%20as%20numpy%20fancy-index%20without%20integer%20cast**%0A%0A%60df.get_column%28dim_col%29.to_numpy%28%29%60%20preserves%20the%20parquet%20column%20dtype.%20If%20the%20embedding%20producer%20serialises%20dimension%20indices%20as%20floating-point%20%28e.g.%2C%20%60Float64%60%29%2C%20%60dims%60%20will%20be%20a%20%60float64%60%20array%20and%20the%20scatter%20%60X%5Bcodes%2C%20dims%5D%20%3D%20vals%60%20will%20raise%20%60IndexError%3A%20only%20integers%2C%20slices%2C%20ellipsis%E2%80%A6%60%20at%20runtime.%20A%20defensive%20cast%20keeps%20the%20code%20robust%20against%20non-standard%20producers%20and%20matches%20the%20explicit%20%60cast%28pl.Float32%29%60%20already%20applied%20to%20%60vals%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20dims%20%3D%20df.get_column%28dim_col%29.cast%28pl.Int64%29.to_numpy%28%29%20%20%23%20per-row%20embeddingDim%20index%20%28int%20required%20for%20indexing%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asoftware%2Fumap%2Fsrc%2Fmain.py%3A1136-1140%0A**Inconsistent%20RNG%20style%20in%20%60run_embedding_umap%60**%0A%0A%60_fit_sample%60%20uses%20the%20new-style%20%60np.random.default_rng%28RANDOM_STATE%29%60%2C%20which%20is%20isolated%20and%20reproducible.%20The%20CPU%20sampling%20here%20falls%20back%20to%20the%20global%20%60np.random.seed%60%20%2B%20%60np.random.choice%60%2C%20which%20mutates%20global%20state%20and%20is%20deprecated.%20Using%20%60np.random.default_rng%60%20here%20matches%20the%20style%20used%20elsewhere%20in%20this%20file%20for%20the%20embedding%20path.%0A%0A%60%60%60suggestion%0A%20%20%20%20rng%20%3D%20np.random.default_rng%28RANDOM_STATE%29%0A%20%20%20%20if%20n%20%3E%20UMAP_FIT_MAX_SAMPLE_SIZE%3A%0A%20%20%20%20%20%20%20%20print%28f%22Fit%20sample%20%28%7Bn%7D%29%20%3E%20%7BUMAP_FIT_MAX_SAMPLE_SIZE%7D.%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22Sampling%20%7BUMAP_FIT_MAX_SAMPLE_SIZE%7D%20vectors%20for%20UMAP%20fitting.%22%29%0A%20%20%20%20%20%20%20%20idx%20%3D%20rng.choice%28n%2C%20size%3DUMAP_FIT_MAX_SAMPLE_SIZE%2C%20replace%3DFalse%29%0A%60%60%60%0A%0A&repo=platforma-open%2Fclonotype-space&pr=101&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
workflow/src/main.tpl.tengo:93-94
**Missing fallbacks for `dimCol` and `valueCol`**

`keyCol` gets a documented fallback to `"clonotypeKey"` when the annotation is absent, but `dimCol` and `valueCol` have no such guard. If an embedding column's second axis or the value annotation lacks `pl7.app/label`, both fields resolve to `undefined` in Tengo. Depending on how the workflow SDK serialises `undefined` to a CLI arg, the Python script will either receive the literal string `"undefined"` as the column name (causing polars to error with a confusing "column not found") or will throw at template evaluation time. The `keyCol` comment explicitly calls out the dataset-axis label-absence risk, suggesting this pattern is known and the same defensive treatment should be applied here.

### Issue 2 of 3
software/umap/src/main.py:1012
**`dims` used as numpy fancy-index without integer cast**

`df.get_column(dim_col).to_numpy()` preserves the parquet column dtype. If the embedding producer serialises dimension indices as floating-point (e.g., `Float64`), `dims` will be a `float64` array and the scatter `X[codes, dims] = vals` will raise `IndexError: only integers, slices, ellipsis…` at runtime. A defensive cast keeps the code robust against non-standard producers and matches the explicit `cast(pl.Float32)` already applied to `vals`.

```suggestion
    dims = df.get_column(dim_col).cast(pl.Int64).to_numpy()  # per-row embeddingDim index (int required for indexing)
```

### Issue 3 of 3
software/umap/src/main.py:1136-1140
**Inconsistent RNG style in `run_embedding_umap`**

`_fit_sample` uses the new-style `np.random.default_rng(RANDOM_STATE)`, which is isolated and reproducible. The CPU sampling here falls back to the global `np.random.seed` + `np.random.choice`, which mutates global state and is deprecated. Using `np.random.default_rng` here matches the style used elsewhere in this file for the embedding path.

```suggestion
    rng = np.random.default_rng(RANDOM_STATE)
    if n > UMAP_FIT_MAX_SAMPLE_SIZE:
        print(f"Fit sample ({n}) > {UMAP_FIT_MAX_SAMPLE_SIZE}. "
              f"Sampling {UMAP_FIT_MAX_SAMPLE_SIZE} vectors for UMAP fitting.")
        idx = rng.choice(n, size=UMAP_FIT_MAX_SAMPLE_SIZE, replace=False)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update SDK"](https://github.com/platforma-open/clonotype-space/commit/b3601d72f38516b90610530c1bdb86b9edbfa0b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38611223)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->