### PR TITLE
SDK update

### DIFF
--- a/.changeset/some-ads-bathe.md
+++ b/.changeset/some-ads-bathe.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.clonotype-space.model": patch
+---
+
+SDK update

--- a/package.json
+++ b/package.json
@@ -20,5 +20,20 @@
     "typescript": "catalog:",
     "shx": "catalog:"
   },
-  "packageManager": "pnpm@9.14.4"
+  "packageManager": "pnpm@9.14.4",
+  "//pnpm": {
+    "overrides": {
+      "@milaboratories/pf-plots": "link:../../core/visualizations/packages/pf-plots",
+      "@milaboratories/multi-sequence-alignment": "link:../../core/visualizations/packages/multi-sequence-alignment",
+      "@platforma-sdk/model": "file:../../core/platforma/sdk/model/package.tgz",
+      "@platforma-sdk/ui-vue": "file:../../core/platforma/sdk/ui-vue/package.tgz",
+      "@milaboratories/pl-model-common": "file:../../core/platforma/lib/model/common/package.tgz",
+      "@milaboratories/pl-model-middle-layer": "file:../../core/platforma/lib/model/middle-layer/package.tgz",
+      "@milaboratories/helpers": "file:../../core/platforma/lib/util/helpers/package.tgz",
+      "@milaboratories/pl-error-like": "file:../../core/platforma/lib/model/pl-error-like/package.tgz",
+      "@milaboratories/ptabler-expression-js": "file:../../core/platforma/lib/ptabler/js/package.tgz",
+      "@milaboratories/pf-spec-driver": "file:../../core/platforma/lib/model/pf-spec-driver/package.tgz",
+      "@milaboratories/uikit": "file:../../core/platforma/lib/ui/uikit/package.tgz"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.79.6
-      version: 1.79.6
+      specifier: 1.79.14
+      version: 1.79.14
     '@platforma-sdk/package-builder':
       specifier: 3.13.0
       version: 3.13.0
@@ -46,11 +46,11 @@ catalogs:
       specifier: 4.0.8
       version: 4.0.8
     '@platforma-sdk/test':
-      specifier: 1.79.13
-      version: 1.79.13
+      specifier: 1.79.14
+      version: 1.79.14
     '@platforma-sdk/ui-vue':
-      specifier: 1.79.11
-      version: 1.79.11
+      specifier: 1.79.14
+      version: 1.79.14
     '@platforma-sdk/workflow-tengo':
       specifier: 6.6.3
       version: 6.6.3
@@ -77,7 +77,7 @@ catalogs:
       version: 6.4.1
     vitest:
       specifier: ^4.0.18
-      version: 4.0.18
+      version: 4.1.3
     vue:
       specifier: 3.5.24
       version: 3.5.24
@@ -115,7 +115,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.6
+        version: 1.79.14
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
@@ -125,13 +125,13 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.6
+        version: 1.79.14
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
@@ -156,7 +156,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.4)(lightningcss@1.32.0)(yaml@2.8.2)
+        version: 4.1.3(@types/node@24.10.4)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2))
 
   software/umap:
     devDependencies:
@@ -175,25 +175,25 @@ importers:
     devDependencies:
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.13(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+        version: 1.79.14(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
       typescript:
         specifier: 'catalog:'
         version: 5.6.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)
+        version: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
 
   ui:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.16(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.16(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -202,10 +202,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.6
+        version: 1.79.14
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@vueuse/core':
         specifier: 'catalog:'
         version: 13.9.0(vue@3.5.24(typescript@5.6.3))
@@ -233,7 +233,7 @@ importers:
         version: 6.4.1(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)
+        version: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@6.4.1(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))
 
   workflow:
     dependencies:
@@ -1361,8 +1361,8 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.64.31':
-    resolution: {integrity: sha512-5ElnNEog3PvGBe3NIOIi3BhOhAWYnikHu4eV5Ms6fBTnag8TklZPF3of4RnvtFI+oSroQ0immqNmufleLoqOkw==}
+  '@milaboratories/pl-middle-layer@1.64.32':
+    resolution: {integrity: sha512-tBBTm3EsVfJQDTsaUbG/gD889etZGS2qmOS//51l+YCtWzEmPmnNDvMHlI5rmIYOtuQJH91ZmvFEPj3nGCweqw==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-model-backend@1.4.7':
@@ -1412,8 +1412,8 @@ packages:
     resolution: {integrity: sha512-HK3AmNZl2fOzMHot2+ihKsOC+fluwhl5261VTn1zGS3LRpmC9bCk/po8SzsVmg79ccI5nESFTdz+BRaLsXncmQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.15.7':
-    resolution: {integrity: sha512-R1bHkxgYokVB7QKkVTAC3Zmdv2acskOGqd/vw/tpg0xsGKO2aUQ4k+gEp0dEsC4yf4nA0zU9Dd6oNGJ1NA3NeQ==}
+  '@milaboratories/uikit@2.15.8':
+    resolution: {integrity: sha512-kyG9VJI7zeX6XQIu+93qFJFTvoOeoW7AqNdtkrTmSHet4FNCdYfp05DKA2lku6WuiYg/bHfpEhRLbu7US8Fs9g==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -1785,8 +1785,8 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.79.6':
-    resolution: {integrity: sha512-aLgxJQQj07+uNYXiQHvFwFG34tgDC+NxvihMJ89dYKdgLPGDMlamIN4bxXco4W3uFqujQNTOqMed7cMeF3UYxA==}
+  '@platforma-sdk/model@1.79.14':
+    resolution: {integrity: sha512-ywF+pV3twqbZfuGv+fphE7HKZzYY9/xYIM9gvhM3Ps/qusIf98997C8Ickky1uHd6AHk8YUX78HCR4hJkD7FyQ==}
 
   '@platforma-sdk/package-builder@3.13.0':
     resolution: {integrity: sha512-5dMFx1S8cotsWd9rccJlyRH00j43f9JFzLmuMGqwKCdfv+T0TADBWvbFRv1oD+kr5gRGj++Ud5GUIVVUUr6suw==}
@@ -1797,11 +1797,11 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.79.13':
-    resolution: {integrity: sha512-oOuFmVYGywk7Y1h0P5PbdGSSsI3HbGGToy44uDUrFGcpqMHIVC0j20mTVKz8rzaiWkIVBhEznPAblywlq3ltFw==}
+  '@platforma-sdk/test@1.79.14':
+    resolution: {integrity: sha512-YswflyuQRmZ6pgkR0+gL6YN38bt/MFuugnBG6NJpjkda/SSoXaiIb3HcBNw0Y+mpyAQPHMoSyHr7ZyZGpvZVDA==}
 
-  '@platforma-sdk/ui-vue@1.79.11':
-    resolution: {integrity: sha512-i5rC0xfdKNRTDRNO53l9/Xte0gIJDBrKk59f3pHXrUBhxef5CnNd9tqdWAu7Dw+6SZT2cQmS3+QvfvdqzbkHFw==}
+  '@platforma-sdk/ui-vue@1.79.14':
+    resolution: {integrity: sha512-KRc+4YOKKes1uwpKBgx9PeJozpGOS2uLt4XljgFupnoU4PyNZjw2I8ZTLtvq0Ld9o5T/ieUCRgiXgx4i4O+QBg==}
 
   '@platforma-sdk/workflow-tengo@6.6.3':
     resolution: {integrity: sha512-2H83hEd+t8pIcSpz0anmWb0wesEcoXCYl9HSOcfQL9b0ro6EDf+PwyafXtmbXl2kMtkpccigbhDGZdDhoMpr7w==}
@@ -3829,7 +3829,6 @@ packages:
 
   '@types/minimatch@6.0.0':
     resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
-    deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -3974,22 +3973,8 @@ packages:
     peerDependencies:
       vitest: 4.1.3
 
-  '@vitest/expect@4.0.18':
-    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
-
   '@vitest/expect@4.1.3':
     resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
-
-  '@vitest/mocker@4.0.18':
-    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
 
   '@vitest/mocker@4.1.3':
     resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
@@ -4002,32 +3987,17 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.18':
-    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
-
   '@vitest/pretty-format@4.1.3':
     resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
-
-  '@vitest/runner@4.0.18':
-    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
   '@vitest/runner@4.1.3':
     resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
 
-  '@vitest/snapshot@4.0.18':
-    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
-
   '@vitest/snapshot@4.1.3':
     resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
 
-  '@vitest/spy@4.0.18':
-    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
-
   '@vitest/spy@4.1.3':
     resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
-
-  '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   '@vitest/utils@4.1.3':
     resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
@@ -5163,12 +5133,10 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -5270,7 +5238,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -5850,10 +5817,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -5896,10 +5859,6 @@ packages:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5907,7 +5866,6 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -6200,9 +6158,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
@@ -6296,7 +6251,6 @@ packages:
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -6325,10 +6279,6 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
-
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
-    engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -6508,7 +6458,6 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-plugin-commonjs@0.10.4:
@@ -6549,46 +6498,6 @@ packages:
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  vite@7.3.0:
-    resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -6657,40 +6566,6 @@ packages:
       tsx:
         optional: true
       yaml:
-        optional: true
-
-  vitest@4.0.18:
-    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.18
-      '@vitest/browser-preview': 4.0.18
-      '@vitest/browser-webdriverio': 4.0.18
-      '@vitest/ui': 4.0.18
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@4.1.3:
@@ -8402,14 +8277,14 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.9
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)
-      '@platforma-sdk/model': 1.79.6
-      '@platforma-sdk/ui-vue': 1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)
+      '@platforma-sdk/model': 1.79.14
+      '@platforma-sdk/ui-vue': 1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.9.0(vue@3.5.26(typescript@5.6.3))
@@ -8466,13 +8341,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.16(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.16(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.3
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)
-      '@platforma-sdk/model': 1.79.6
-      '@platforma-sdk/ui-vue': 1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)
+      '@platforma-sdk/model': 1.79.14
+      '@platforma-sdk/ui-vue': 1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.26(typescript@5.6.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -8497,11 +8372,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)':
+  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.1
-      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/model': 1.79.14
       canonicalize: 2.1.0
       lodash: 4.17.21
 
@@ -8632,7 +8507,7 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.64.31(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)':
+  '@milaboratories/pl-middle-layer@1.64.32(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/helpers': 1.14.2
@@ -8652,7 +8527,7 @@ snapshots:
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.3
       '@platforma-sdk/block-tools': 2.11.0(@types/node@25.0.3)
-      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/model': 1.79.14
       '@platforma-sdk/workflow-tengo': 6.6.3
       canonicalize: 2.1.0
       denque: 2.1.0
@@ -8820,10 +8695,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.7(typescript@5.6.3)':
+  '@milaboratories/uikit@2.15.8(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/model': 1.79.14
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -9219,7 +9094,7 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.51.0(eslint@9.39.2)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.79.6':
+  '@platforma-sdk/model@1.79.14':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
@@ -9259,15 +9134,15 @@ snapshots:
       '@oclif/core': 4.8.0
       winston: 3.19.0
 
-  '@platforma-sdk/test@1.79.13(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/pl-client': 3.11.4
-      '@milaboratories/pl-middle-layer': 1.64.31(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)
+      '@milaboratories/pl-middle-layer': 1.64.32(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)
       '@milaboratories/pl-tree': 1.12.12
-      '@platforma-sdk/model': 1.79.6
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)))
-      vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+      '@platforma-sdk/model': 1.79.14
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
+      vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - '@edge-runtime/vm'
@@ -9289,12 +9164,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/pf-spec-driver': 1.4.13(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-model-common': 1.46.1
-      '@milaboratories/uikit': 2.15.7(typescript@5.6.3)
-      '@platforma-sdk/model': 1.79.6
+      '@milaboratories/uikit': 2.15.8(typescript@5.6.3)
+      '@platforma-sdk/model': 1.79.14
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -12276,7 +12151,7 @@ snapshots:
       vite: 8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)
       vue: 3.5.24(typescript@5.6.3)
 
-  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)))':
+  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -12288,18 +12163,9 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+      vitest: 4.1.3(@types/node@24.10.4)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
-
-  '@vitest/expect@4.0.18':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      chai: 6.2.2
-      tinyrainbow: 3.0.3
 
   '@vitest/expect@4.1.3':
     dependencies:
@@ -12310,21 +12176,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.18(vite@7.3.0(@types/node@24.10.4)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.3(vite@6.4.1(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@24.10.4)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.0.18(vite@7.3.0(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.3(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)
+      vite: 8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2)
 
   '@vitest/mocker@4.1.3(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))':
     dependencies:
@@ -12334,28 +12200,13 @@ snapshots:
     optionalDependencies:
       vite: 8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)
 
-  '@vitest/pretty-format@4.0.18':
-    dependencies:
-      tinyrainbow: 3.0.3
-
   '@vitest/pretty-format@4.1.3':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.0.18':
-    dependencies:
-      '@vitest/utils': 4.0.18
-      pathe: 2.0.3
-
   '@vitest/runner@4.1.3':
     dependencies:
       '@vitest/utils': 4.1.3
-      pathe: 2.0.3
-
-  '@vitest/snapshot@4.0.18':
-    dependencies:
-      '@vitest/pretty-format': 4.0.18
-      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.3':
@@ -12365,14 +12216,7 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.18': {}
-
   '@vitest/spy@4.1.3': {}
-
-  '@vitest/utils@4.0.18':
-    dependencies:
-      '@vitest/pretty-format': 4.0.18
-      tinyrainbow: 3.0.3
 
   '@vitest/utils@4.1.3':
     dependencies:
@@ -13284,6 +13128,7 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.2
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
+    optional: true
 
   escalade@3.2.0: {}
 
@@ -13473,9 +13318,9 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fecha@4.2.3: {}
 
@@ -14218,8 +14063,6 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pify@2.3.0: {}
@@ -14261,12 +14104,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.9:
     dependencies:
@@ -14624,8 +14461,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
-
   std-env@4.0.0: {}
 
   stream-browserify@3.0.0:
@@ -14770,12 +14605,10 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@2.1.0: {}
-
-  tinyrainbow@3.0.3: {}
 
   tinyrainbow@3.1.0: {}
 
@@ -14991,37 +14824,9 @@ snapshots:
   vite@6.4.1(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.55.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.0.3
-      fsevents: 2.3.3
-      lightningcss: 1.32.0
-      yaml: 2.8.2
-
-  vite@7.3.0(@types/node@24.10.4)(lightningcss@1.32.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.55.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.10.4
-      fsevents: 2.3.3
-      lightningcss: 1.32.0
-      yaml: 2.8.2
-
-  vite@7.3.0(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.9
       rollup: 4.55.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -15056,81 +14861,63 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@24.10.4)(lightningcss@1.32.0)(yaml@2.8.2):
+  vitest@4.1.3(@types/node@24.10.4)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.0(@types/node@24.10.4)(lightningcss@1.32.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
+      picomatch: 4.0.4
+      std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@24.10.4)(lightningcss@1.32.0)(yaml@2.8.2)
+      tinyrainbow: 3.1.0
+      vite: 8.0.7(@types/node@24.10.4)(esbuild@0.27.2)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.4
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2):
+  vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@6.4.1(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.0(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@6.4.1(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
+      picomatch: 4.0.4
+      std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)):
+  vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.3
       '@vitest/mocker': 4.1.3(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
@@ -15154,7 +14941,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@25.0.3)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2)))
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,13 +11,13 @@ catalog:
   '@milaboratories/ts-builder': 1.5.2
   '@milaboratories/ts-configs': 1.2.3
   '@platforma-sdk/workflow-tengo': 6.6.3
-  '@platforma-sdk/model': 1.79.6
-  '@platforma-sdk/ui-vue': 1.79.11
+  '@platforma-sdk/model': 1.79.14
+  '@platforma-sdk/ui-vue': 1.79.14
   '@platforma-sdk/tengo-builder': 4.0.8
   '@platforma-sdk/package-builder': 3.13.0
   '@platforma-sdk/block-tools': 2.11.0
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.79.13
+  '@platforma-sdk/test': 1.79.14
   '@milaboratories/helpers': 1.14.2
   '@milaboratories/graph-maker': 1.4.6
   '@milaboratories/multi-sequence-alignment': 1.47.16


### PR DESCRIPTION
Fix for https://app.notion.com/p/mixcr/blocks-clonotype-space-MSA-not-working-when-redefine-clonotypes-block-is-upstream-3823a83ff4af809b9491efe2fb969608?v=1e03a83ff4af8098954e000c3ee90fd8&source=copy_link

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps a suite of Platforma SDK packages to their latest versions and regenerates the lockfile. A `"//pnpm"` overrides block with local `link:`/`file:` paths was also added to `package.json`, which appears to be a leftover development artifact.

- **SDK version bumps** (`pnpm-workspace.yaml`): `@platforma-sdk/model` 1.78.9→1.79.14, `@platforma-sdk/ui-vue` 1.78.11→1.79.14, `@platforma-sdk/test` 1.78.10→1.79.14, `@platforma-sdk/workflow-tengo` 6.3.2→6.6.3, `@platforma-sdk/block-tools` 2.10.9→2.11.0, `@platforma-sdk/tengo-builder` 4.0.7→4.0.8, `@milaboratories/ts-builder` 1.5.0→1.5.2.
- **Lockfile update** (`pnpm-lock.yaml`): Reflects all catalog bumps; new transitive dependencies pulled in include the full `@inquirer/prompts` suite, `better-sqlite3`, `prebuild-install`, and related native-addon utilities.
- **Local dev overrides** (`package.json`): A `\"//pnpm\"` block mapping several packages to local `link:` and `file:` paths was added — this key is ignored by pnpm but should be removed before merging.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge once the local-path //pnpm overrides block is removed from package.json

The SDK version bumps and lockfile regeneration are clean and consistent. The only concern is the //pnpm block in package.json that embeds local link: and file: paths referencing the author's private directory layout. Because pnpm ignores the //pnpm key entirely, it does not affect any builds today — but it shouldn't be part of the repository history as it encodes a machine-specific dev setup.

package.json — the //pnpm overrides block with local file paths should be reverted before merging
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds a "//pnpm" overrides block with local link: and file: paths — appears to be a leftover local development artifact that should not be committed |
| pnpm-workspace.yaml | Catalog versions for SDK packages updated cleanly: @platforma-sdk/model 1.78.9→1.79.14, @platforma-sdk/ui-vue 1.78.11→1.79.14, @platforma-sdk/test 1.78.10→1.79.14, @platforma-sdk/workflow-tengo 6.3.2→6.6.3, @platforma-sdk/block-tools 2.10.9→2.11.0, @platforma-sdk/tengo-builder 4.0.7→4.0.8, @milaboratories/ts-builder 1.5.0→1.5.2 |
| pnpm-lock.yaml | Lockfile regenerated to reflect all catalog version bumps; new transitive dependencies added (inquirer prompts suite, better-sqlite3, prebuild-install, and related native addon helpers) |
| .changeset/some-ads-bathe.md | New changeset marking @platforma-open/milaboratories.clonotype-space.model for a patch release |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    WS[pnpm-workspace.yaml\ncatalog updates] --> MODEL["@platforma-sdk/model\n1.78.9 → 1.79.14"]
    WS --> UIVUE["@platforma-sdk/ui-vue\n1.78.11 → 1.79.14"]
    WS --> TEST["@platforma-sdk/test\n1.78.10 → 1.79.14"]
    WS --> TENGO["@platforma-sdk/workflow-tengo\n6.3.2 → 6.6.3"]
    WS --> BTOOLS["@platforma-sdk/block-tools\n2.10.9 → 2.11.0"]
    WS --> TBUILDER["@platforma-sdk/tengo-builder\n4.0.7 → 4.0.8"]
    WS --> TSBUILDER["@milaboratories/ts-builder\n1.5.0 → 1.5.2"]
    MODEL --> LOCK[pnpm-lock.yaml\nregenerated]
    UIVUE --> LOCK
    TEST --> LOCK
    TENGO --> LOCK
    BTOOLS --> LOCK
    TBUILDER --> LOCK
    TSBUILDER --> LOCK
    LOCK --> NEW["New transitive deps\n(@inquirer/prompts, better-sqlite3,\nprebuild-install, …)"]
    PKG[package.json] --> WARN["⚠️ //pnpm overrides\nlink:/file: local paths\n(ignored by pnpm, should be removed)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    WS[pnpm-workspace.yaml\ncatalog updates] --> MODEL["@platforma-sdk/model\n1.78.9 → 1.79.14"]
    WS --> UIVUE["@platforma-sdk/ui-vue\n1.78.11 → 1.79.14"]
    WS --> TEST["@platforma-sdk/test\n1.78.10 → 1.79.14"]
    WS --> TENGO["@platforma-sdk/workflow-tengo\n6.3.2 → 6.6.3"]
    WS --> BTOOLS["@platforma-sdk/block-tools\n2.10.9 → 2.11.0"]
    WS --> TBUILDER["@platforma-sdk/tengo-builder\n4.0.7 → 4.0.8"]
    WS --> TSBUILDER["@milaboratories/ts-builder\n1.5.0 → 1.5.2"]
    MODEL --> LOCK[pnpm-lock.yaml\nregenerated]
    UIVUE --> LOCK
    TEST --> LOCK
    TENGO --> LOCK
    BTOOLS --> LOCK
    TBUILDER --> LOCK
    TSBUILDER --> LOCK
    LOCK --> NEW["New transitive deps\n(@inquirer/prompts, better-sqlite3,\nprebuild-install, …)"]
    PKG[package.json] --> WARN["⚠️ //pnpm overrides\nlink:/file: local paths\n(ignored by pnpm, should be removed)"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackage.json%3A24-38%0A**Local%20development%20overrides%20committed%20to%20repository**%0A%0AThe%20%60%22%2F%2Fpnpm%22%60%20block%20contains%20%60link%3A%60%20and%20%60file%3A%60%20paths%20to%20local%20file%20system%20locations%20%28e.g.%2C%20%60link%3A..%2F..%2Fcore%2Fvisualizations%2Fpackages%2Fpf-plots%60%2C%20%60file%3A..%2F..%2Fcore%2Fplatforma%2Fsdk%2Fmodel%2Fpackage.tgz%60%29.%20These%20paths%20are%20specific%20to%20the%20author's%20local%20monorepo%20checkout%20and%20won't%20exist%20in%20CI%20or%20for%20any%20other%20contributor.%20This%20block%20appears%20to%20be%20a%20local%20development%20scaffold%20that%20was%20accidentally%20included%20in%20the%20PR.%20Because%20the%20key%20is%20%60%22%2F%2Fpnpm%22%60%20%28not%20%60%22pnpm%22%60%29%2C%20pnpm%20ignores%20it%20entirely%2C%20so%20it%20doesn't%20break%20builds%20%E2%80%94%20but%20committing%20local%20development%20paths%20into%20the%20repository%20is%20misleading%20and%20may%20cause%20future%20contributors%20to%20adopt%20the%20wrong%20workflow.%0A%0A&repo=platforma-open%2Fclonotype-space&pr=102&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
package.json:24-38
**Local development overrides committed to repository**

The `"//pnpm"` block contains `link:` and `file:` paths to local file system locations (e.g., `link:../../core/visualizations/packages/pf-plots`, `file:../../core/platforma/sdk/model/package.tgz`). These paths are specific to the author's local monorepo checkout and won't exist in CI or for any other contributor. This block appears to be a local development scaffold that was accidentally included in the PR. Because the key is `"//pnpm"` (not `"pnpm"`), pnpm ignores it entirely, so it doesn't break builds — but committing local development paths into the repository is misleading and may cause future contributors to adopt the wrong workflow.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["SDK update"](https://github.com/platforma-open/clonotype-space/commit/fb8837cf8e32a724973345536ec9307f1a219350) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38623089)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->