### PR TITLE
Milab 6417 reduce cpu on gpu

### DIFF
--- a/.changeset/gpu-cpu-reduce.md
+++ b/.changeset/gpu-cpu-reduce.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.clonotype-space.workflow": patch
+---
+
+Reduce CPU request to 1 when GPU is in use. On a GPU node, the heavy compute (SVD/PCA, UMAP) runs on the GPU and the CPU only orchestrates the run plus the small k-mer counting step — so the workflow now requests just 1 CPU when `requireGpu && exec.hasGpu`, both for the exec resource and the Python `--n-jobs` flag. Keeps GPU pools densely packed without meaningfully hurting wall-clock for typical clonotype counts.

--- a/workflow/src/umap-calculation.tpl.tengo
+++ b/workflow/src/umap-calculation.tpl.tengo
@@ -25,17 +25,25 @@ self.body(func(args) {
     // working sets that the GPU path can't avoid.
     useGpu := requireGpu && exec.hasGpu
     effectiveMem := mem
+    effectiveCpu := cpu
     if useGpu {
         effectiveMem = mem / 4
         if effectiveMem < 8 {
             effectiveMem = 8
         }
+        // On a GPU node the heavy compute (SVD/PCA, UMAP) runs on the GPU; the
+        // CPU only orchestrates the run plus the small k-mer counting step.
+        // Dropping the CPU request to 1 keeps the GPU pool densely packed (one
+        // job per node won't reserve cores it can't use) without meaningfully
+        // hurting wall-clock — k-mer counting is bounded by L̄·N and finishes
+        // in seconds even single-threaded for typical clonotype counts.
+        effectiveCpu = 1
     }
 
     builder := exec.builder().
         software(assets.importSoftware("@platforma-open/milaboratories.clonotype-space.umap:main")).
         mem(string(effectiveMem) + "GiB").
-        cpu(cpu)
+        cpu(effectiveCpu)
 
     if useGpu {
         // 16 GiB fallback when the user leaves the GPU memory field empty
@@ -56,7 +64,7 @@ self.body(func(args) {
             arg("-u").arg("umap.tsv").
             arg("--umap-neighbors").arg(string(umap_neighbors)).
             arg("--umap-min-dist").arg(string(umap_min_dist)).
-            arg("--n-jobs").arg(string(cpu))
+            arg("--n-jobs").arg(string(effectiveCpu))
 
         // Embedding model: logged to the processing log for provenance. Undefined if the column
         // lacks the domain key — omit the flag rather than pass an empty string.
@@ -96,7 +104,7 @@ self.body(func(args) {
             arg("--alphabet").arg(alphabet).
             arg("--k-mer-size").arg(string(kmerSize)).
             arg("--encoding").arg(encoding).
-            arg("--n-jobs").arg(string(cpu))
+            arg("--n-jobs").arg(string(effectiveCpu))
     }
 
     // UMAP software execution


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds explicit GPU scheduling to the clonotype-space UMAP block: a `requireGpu` checkbox (default on) and a `gpuMemory` number field let users request a GPU node via `exec.builder().gpuMemory(…)`, replacing the previous implicit runtime probe. When a GPU node is available and `requireGpu` is true, the workflow also reduces the CPU allocation to 1 and scales RAM down by 4× (8 GiB floor) to pack GPU pools more densely.

**Key terms touched:**
- **`requireGpu`** (`BlockData` / `BlockArgs`): new boolean that gates the `.gpuMemory()` call; when `false`, the block always runs on CPU regardless of hardware.
- **`gpuMemory`** (`BlockData` / `BlockArgs`): optional VRAM request in GiB; `undefined` lets the workflow fall back to 16 GiB.
- **`useGpu`** (Tengo): derived `requireGpu && exec.hasGpu`; the single guard point for all GPU-specific resource adjustments.
- **`effectiveMem` / `effectiveCpu`** (Tengo): the actual `mem` / `cpu` values submitted to the executor — on GPU nodes these become `max(mem/4, 8)` and `1` respectively.
- **`_mark_exec()`** (Python): stamps a definitive `>>> SVD/UMAP EXECUTED ON GPU|CPU` log line at the exact return site of each compute stage.
- **`_EXEC`** (Python): module-level dict recording which backend actually ran `svd` and `umap`; consumed by the `COMPUTATION SUMMARY` at the end of `main()`.
- **`log_gpu_status()`** (Python): startup banner probing CUDA availability before any heavy work begins.

- Adds `requireGpu` (default `true`) and optional `gpuMemory` to `BlockData`, `BlockArgs`, and the V3 data model; the `upgradeLegacy` path seeds both fields so existing projects load without errors.
- The Python UMAP software gains a `GPU STATUS:` startup banner, per-stage `>>> SVD/UMAP EXECUTED ON …` markers via `_mark_exec()`, and a closing `COMPUTATION SUMMARY:` block — but the summary is only reached on the k-mer/pos-kmer code paths; embedding mode (`--encoding embedding`) exits before it.
- Toolchain updated across the workspace: TypeScript bumped to 5.9.3, `@types/node` moved to peer deps, `eslint.config.mjs` replaced with `oxlint`/`oxfmt` configs.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The GPU resource path, CPU/RAM reduction logic, and Python backend markers all look correct; the one concrete defect is the missing COMPUTATION SUMMARY for embedding-mode runs.

The new GPU scheduling plumbing is straightforward and the fallback to CPU on non-GPU backends is properly gated by `exec.hasGpu`. The one real defect is that `main.py` exits via an early `return` in embedding mode before reaching the `COMPUTATION SUMMARY` block — operators searching logs for that line will find it absent on every embedding-mode run. The pnpm version downgrade in `package.json` is a low-risk toolchain inconsistency, and the legacy upgrade defaulting to `requireGpu: true` is a behavioural change that could silently move existing projects onto GPU nodes.

software/umap/src/main.py (missing COMPUTATION SUMMARY for embedding mode), package.json (pnpm downgrade), model/src/dataModel.ts (legacy upgrade GPU default)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/umap-calculation.tpl.tengo | New GPU/CPU decision logic: computes `useGpu`, `effectiveMem` (÷4 with 8 GiB floor), and `effectiveCpu` (forced to 1 on GPU nodes); calls `.gpuMemory()` only when `useGpu` is true; correctly passes `--n-jobs` matching `effectiveCpu` in both input modes. |
| software/umap/src/main.py | Adds `log_gpu_status()` banner, per-stage `_mark_exec()` markers, and `COMPUTATION SUMMARY` at end of `main()` — but the summary block is bypassed for `--encoding embedding` runs due to an early `return` at line 1454. |
| model/src/dataModel.ts | Adds `requireGpu` and `gpuMemory` to both `init()` and `upgradeLegacy()`; `requireGpu: true` default in upgrade path silently opts existing CPU-only projects into GPU scheduling. |
| model/src/types.ts | Adds `requireGpu: boolean` and `gpuMemory?: number` to `BlockData` and `BlockArgs`; documentation is clear on fallback semantics. |
| ui/src/pages/UmapPage.vue | Adds "Require run on GPU" checkbox and "GPU memory (GB)" number field; GPU memory max capped at 64 GiB, below the 80 GiB VRAM on A100/H100 GPUs. |
| package.json | `packageManager` downgraded from `pnpm@9.14.4` to `pnpm@9.12.0` (likely unintentional); extra whitespace in `build:dev` script. |
| block/package.json | Adds `gpu` tag to the block descriptor; reorganizes dependencies; no logic issues. |
| workflow/src/process.tpl.tengo | Correctly plumbs `requireGpu` and `gpuMemory` from meta-inputs through to `umapCalculationTpl` in both sequence-features and embedding render paths. |
| workflow/src/main.tpl.tengo | Passes `requireGpu` and `gpuMemory` to the inner process template via `metaInputs`; no logic issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[umap-calculation.tpl.tengo] --> B{requireGpu AND exec.hasGpu?}
    B -- "useGpu=true" --> C["effectiveCpu=1, effectiveMem=max(mem/4,8GiB)"]
    B -- "useGpu=false" --> D["effectiveCpu=cpu, effectiveMem=mem"]
    C --> E["builder.gpuMemory(gpuMemory ?? 16GiB)"]
    D --> F["builder.cpu(cpu).mem(memGiB)"]
    E --> G["exec run with --n-jobs 1"]
    F --> H["exec run with --n-jobs cpu"]
    G --> J[main.py]
    H --> J
    J --> K{--encoding?}
    K -- "embedding" --> L["run_embedding_mode + _mark_exec (no SUMMARY)"]
    K -- "kmer/pos-kmer" --> M["run_gpu/cpu_pipeline + _mark_exec + COMPUTATION SUMMARY"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[umap-calculation.tpl.tengo] --> B{requireGpu AND exec.hasGpu?}
    B -- "useGpu=true" --> C["effectiveCpu=1, effectiveMem=max(mem/4,8GiB)"]
    B -- "useGpu=false" --> D["effectiveCpu=cpu, effectiveMem=mem"]
    C --> E["builder.gpuMemory(gpuMemory ?? 16GiB)"]
    D --> F["builder.cpu(cpu).mem(memGiB)"]
    E --> G["exec run with --n-jobs 1"]
    F --> H["exec run with --n-jobs cpu"]
    G --> J[main.py]
    H --> J
    J --> K{--encoding?}
    K -- "embedding" --> L["run_embedding_mode + _mark_exec (no SUMMARY)"]
    K -- "kmer/pos-kmer" --> M["run_gpu/cpu_pipeline + _mark_exec + COMPUTATION SUMMARY"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Asoftware%2Fumap%2Fsrc%2Fmain.py%3A1446-1454%0A**%60COMPUTATION%20SUMMARY%60%20missing%20for%20embedding%20mode**%0A%0AWhen%20%60--encoding%20embedding%60%20is%20used%20the%20function%20returns%20at%20line%201454%2C%20bypassing%20the%20%60COMPUTATION%20SUMMARY%3A%60%20block%20at%20lines%201528-1533.%20The%20%60_mark_exec%28%29%60%20banners%20inside%20%60run_embedding_mode%60%20still%20fire%2C%20so%20the%20per-stage%20%60%3E%3E%3E%20SVD%2FUMAP%20EXECUTED%20ON%20%E2%80%A6%60%20lines%20appear%2C%20but%20the%20closing%20summary%20is%20never%20printed.%20The%20changeset%20explicitly%20promises%20this%20summary%20for%20every%20run.%0A%0A%23%23%23%20Issue%202%20of%205%0Apackage.json%3A32%0AThe%20%60packageManager%60%20field%20was%20downgraded%20from%20%60pnpm%409.14.4%60%20to%20%60pnpm%409.12.0%60.%20This%20looks%20like%20an%20accidental%20downgrade%3B%20pnpm%20uses%20this%20field%20to%20enforce%20the%20exact%20version%20for%20%60corepack%60-managed%20installs%2C%20so%20developers%20or%20CI%20that%20relied%20on%209.14.4%20will%20be%20forced%20to%20an%20older%20version.%0A%0A%60%60%60suggestion%0A%20%20%22packageManager%22%3A%20%22pnpm%409.14.4%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0Amodel%2Fsrc%2FdataModel.ts%3A244-266%0A**Legacy%20upgrade%20silently%20opts%20existing%20projects%20into%20GPU%20scheduling**%0A%0A%60upgradeLegacy%60%20seeds%20%60requireGpu%3A%20true%60%20for%20every%20project%20that%20predates%20this%20change.%20On%20any%20backend%20that%20has%20a%20GPU%20%28%60exec.hasGpu%60%29%2C%20those%20previously-CPU-only%20runs%20will%20now%20be%20routed%20to%20GPU%20nodes%20and%20request%2016%20GiB%20of%20VRAM%20%E2%80%94%20changing%20their%20resource%20footprint%20without%20any%20user%20action.%20Consider%20defaulting%20to%20%60false%60%20in%20the%20upgrade%20path%20%28keeping%20%60true%60%20only%20for%20%60.init%60%29%20so%20existing%20projects%20retain%20their%20prior%20CPU%20behavior%20unless%20the%20user%20explicitly%20enables%20it.%0A%0A%23%23%23%20Issue%204%20of%205%0Aui%2Fsrc%2Fpages%2FUmapPage.vue%3A514-517%0AThe%20GPU%20memory%20field%20is%20capped%20at%2064%20GiB%2C%20which%20is%20below%20the%20VRAM%20available%20on%20A100%20%2880%20GiB%29%20and%20H100%20%2880%20GiB%29%20GPUs.%20Users%20running%20on%20those%20nodes%20cannot%20request%20their%20full%20available%20VRAM%3B%20the%20workflow%20will%20silently%20under-request%20memory.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Amin%3D%221%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Amax%3D%22128%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Astep%3D%221%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Adisabled%3D%22!app.model.data.requireGpu%22%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Apackage.json%3A4%0AExtra%20spaces%20in%20the%20%60build%3Adev%60%20script%20%28%60env%20%20%20PL_PKG_DEV%60%29%20%E2%80%94%20double%20space%20before%20the%20variable%20name.%20Harmless%20but%20likely%20a%20typo.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22build%3Adev%22%3A%20%22env%20PL_PKG_DEV%3Dlocal%20turbo%20run%20build%22%2C%0A%60%60%60%0A%0A&repo=platforma-open%2Fclonotype-space&pr=103&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
software/umap/src/main.py:1446-1454
**`COMPUTATION SUMMARY` missing for embedding mode**

When `--encoding embedding` is used the function returns at line 1454, bypassing the `COMPUTATION SUMMARY:` block at lines 1528-1533. The `_mark_exec()` banners inside `run_embedding_mode` still fire, so the per-stage `>>> SVD/UMAP EXECUTED ON …` lines appear, but the closing summary is never printed. The changeset explicitly promises this summary for every run.

### Issue 2 of 5
package.json:32
The `packageManager` field was downgraded from `pnpm@9.14.4` to `pnpm@9.12.0`. This looks like an accidental downgrade; pnpm uses this field to enforce the exact version for `corepack`-managed installs, so developers or CI that relied on 9.14.4 will be forced to an older version.

```suggestion
  "packageManager": "pnpm@9.14.4"
```

### Issue 3 of 5
model/src/dataModel.ts:244-266
**Legacy upgrade silently opts existing projects into GPU scheduling**

`upgradeLegacy` seeds `requireGpu: true` for every project that predates this change. On any backend that has a GPU (`exec.hasGpu`), those previously-CPU-only runs will now be routed to GPU nodes and request 16 GiB of VRAM — changing their resource footprint without any user action. Consider defaulting to `false` in the upgrade path (keeping `true` only for `.init`) so existing projects retain their prior CPU behavior unless the user explicitly enables it.

### Issue 4 of 5
ui/src/pages/UmapPage.vue:514-517
The GPU memory field is capped at 64 GiB, which is below the VRAM available on A100 (80 GiB) and H100 (80 GiB) GPUs. Users running on those nodes cannot request their full available VRAM; the workflow will silently under-request memory.

```suggestion
            :min="1"
            :max="128"
            :step="1"
            :disabled="!app.model.data.requireGpu"
```

### Issue 5 of 5
package.json:4
Extra spaces in the `build:dev` script (`env   PL_PKG_DEV`) — double space before the variable name. Harmless but likely a typo.

```suggestion
    "build:dev": "env PL_PKG_DEV=local turbo run build",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6417: reduce CPU request to 1 when..."](https://github.com/platforma-open/clonotype-space/commit/6031d3ec772d8e47acc833d9966147d42dc991f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38636366)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->