### PR TITLE
MILAB-6480: derive UMAP exec RAM and CPU from input size via exec.formula

### DIFF
--- a/.changeset/resource-formulas.md
+++ b/.changeset/resource-formulas.md
@@ -1,0 +1,14 @@
+---
+"@platforma-open/milaboratories.clonotype-space.workflow": patch
+---
+
+MILAB-6480: derive UMAP exec RAM and CPU from input file size via `exec.formula`.
+
+RAM and CPU on the UMAP exec are now computed from the tagged input file
+size at exec time (parquet for the embedding path, tsv for the
+sequence-features path). The CPU path requests ~4× input size in RAM and
+~1 core per 2 GiB of input; the GPU path stays at ~1× RAM and a single
+host core for orchestration. The user's UI-set mem/cpu values become the
+ceiling and the fallback for backends that can't evaluate resource
+formulas (pl < v3.0.4). `--n-jobs` now reads `{system.cpu}` so the binary
+matches the actually-allocated cores.

--- a/workflow/src/umap-calculation.tpl.tengo
+++ b/workflow/src/umap-calculation.tpl.tengo
@@ -40,22 +40,50 @@ self.body(func(args) {
         effectiveCpu = 1
     }
 
+    // Resource formulas: RAM and CPU are computed from the tagged "input" file
+    // size at exec time, with the static .mem()/.cpu() values below acting as
+    // the fallback for backends that can't evaluate formulas (pl < v3.0.4).
+    //
+    // RAM multiplier comes from the same empirical peak-RSS observation as the
+    // GPU divide-by-4 above: CPU path ~4×, GPU path ~1×. The floor handles
+    // Python/polars/k-mer overhead the formula cannot see; the ceiling
+    // honours the user's UI-set memory cap.
+    formula := exec.formula
+    memMultiplier := useGpu ? 1 : 4
+    memFloor := useGpu ? 8 : 16
+    memAst := formula.clamp(
+        formula.mul(formula.size("input"), memMultiplier),
+        formula.gib(memFloor),
+        formula.gib(effectiveMem)
+    )
+
     builder := exec.builder().
         software(assets.importSoftware("@platforma-open/milaboratories.clonotype-space.umap:main")).
         mem(string(effectiveMem) + "GiB").
+        memFormula(memAst).
         cpu(effectiveCpu)
 
     if useGpu {
         // 16 GiB fallback when the user leaves the GPU memory field empty
         effectiveGpuMemory := is_undefined(gpuMemory) ? 16 : gpuMemory
         builder = builder.gpuMemory(string(effectiveGpuMemory) + "GiB")
+        // CPU pinned to 1 on GPU — no formula needed, the static .cpu(1) above
+        // is final.
+    } else {
+        // CPU path: scale ~1 core per 2 GiB of input, floored at 4 so k-mer
+        // multiprocess pool stays usable, capped at the user's UI setting.
+        builder = builder.cpuFormula(formula.clamp(
+            formula.divCeil(formula.size("input"), formula.gib(2)),
+            4,
+            effectiveCpu
+        ))
     }
 
     if inputMode == "embedding" {
         // Embedding feature path: main.py reads the exported Parquet matrix instead of counting k-mers
         // (--encoding embedding), then runs centered PCA-95% -> L2-normalize -> Euclidean UMAP.
         builder = builder.
-            addFile("embedding.parquet", args.embeddingMatrix).
+            addFile("embedding.parquet", args.embeddingMatrix, { tag: "input" }).
             arg("--encoding").arg("embedding").
             arg("--matrix").arg("embedding.parquet").
             arg("--key-col").arg(args.keyCol).
@@ -64,7 +92,7 @@ self.body(func(args) {
             arg("-u").arg("umap.tsv").
             arg("--umap-neighbors").arg(string(umap_neighbors)).
             arg("--umap-min-dist").arg(string(umap_min_dist)).
-            arg("--n-jobs").arg(string(effectiveCpu))
+            arg("--n-jobs").argExpr("{system.cpu}")
 
         // Embedding model: logged to the processing log for provenance. Undefined if the column
         // lacks the domain key — omit the flag rather than pass an empty string.
@@ -95,7 +123,7 @@ self.body(func(args) {
         // Note: --seq-col-start "sequence" will match all columns starting with "sequence"
         // (sequence.TRA, sequence.TRB, sequence_0, etc.)
         builder = builder.
-            addFile("sequences.tsv", args.umapTable).
+            addFile("sequences.tsv", args.umapTable, { tag: "input" }).
             arg("-i").arg("sequences.tsv").
             arg("-c").arg("sequence").
             arg("-u").arg("umap.tsv").
@@ -104,7 +132,7 @@ self.body(func(args) {
             arg("--alphabet").arg(alphabet).
             arg("--k-mer-size").arg(string(kmerSize)).
             arg("--encoding").arg(encoding).
-            arg("--n-jobs").arg(string(effectiveCpu))
+            arg("--n-jobs").argExpr("{system.cpu}")
     }
 
     // UMAP software execution


### PR DESCRIPTION
## Summary

First slice of [MILAB-6480](https://www.notion.so/mixcr/backend-Add-GPU-to-formulas-implementation-and-make-first-block-use-it-3873a83ff4af804c8740d6f0cb61b1f3) — make clonotype-space the canonical example of a block driving its `exec` RAM/CPU from input file size via `exec.formula`.

- Tag the UMAP exec input file (`"input"`) on both the embedding (`embedding.parquet`) and sequence-features (`sequences.tsv`) paths.
- `.memFormula(...)` derives RAM from `f.size("input")`: ~4× on the CPU path, ~1× on the GPU path (heavy state lives in VRAM there), clamped between an OS/Python/k-mer-pool floor and the user's UI-set mem ceiling.
- `.cpuFormula(...)` on the CPU path scales ~1 core per 2 GiB of input, floored at 4 for k-mer multiprocess parallelism, capped at the user's UI-set cpu ceiling. GPU path stays at a static `cpu(1)` — orchestration only.
- Static `.mem()/.cpu()` calls remain as the fallback for backends that can't evaluate resource formulas (pl < v3.0.4).
- `--n-jobs` switched from `string(effectiveCpu)` to `argExpr("{system.cpu}")` so the binary picks up the formula-allocated core count.

## Open items / follow-ups

- [ ] Validate empirically against real-sized inputs (large parquet embeddings, large clonotype TSVs) and tune the multipliers / floors if needed.
- [ ] Boilerplate (`@platforma-open/.../boilerplate`) should mirror this pattern — covered by the broader MILAB-6480 acceptance criteria, not in this PR.
- [ ] Watch for `gpuFormula`/GPU memory formulas if/when the SDK gains them; today only mem and cpu are formula-driven.

## Tech notes

- SDK: [platforma#1678](https://github.com/milaboratory/platforma/pull/1678)
- Spec: `docs/text/work/projects/workflow-sdk/03-resource-formulas.md`

## Test plan

- [ ] `pnpm --filter "*workflow*" build` (done locally — passes)
- [ ] `pl-tengo check` (done locally — passes)
- [ ] Block tests against a local pl backend (TODO)
- [ ] Manual run on a real project with a large embedding and a large sequence input, comparing allocated RAM/CPU vs. previous static values