### PR TITLE
fix: default missing requireGpu in stored args to true

### DIFF
--- a/.changeset/old-invalid-params.md
+++ b/.changeset/old-invalid-params.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.clonotype-space.model": patch
+---
+
+Treat missing `requireGpu` in stored block data as `false`. Projects saved before the field was added to `V20260518` came back with `requireGpu === undefined`, which the args lambda rejected and disabled the Run button. The lambda now coerces `undefined → false` instead of throwing.

--- a/.changeset/old-invalid-params.md
+++ b/.changeset/old-invalid-params.md
@@ -2,4 +2,4 @@
 "@platforma-open/milaboratories.clonotype-space.model": patch
 ---
 
-Treat missing `requireGpu` in stored block data as `false`. Projects saved before the field was added to `V20260518` came back with `requireGpu === undefined`, which the args lambda rejected and disabled the Run button. The lambda now coerces `undefined → false` instead of throwing.
+Default missing `requireGpu` in stored block data to `true`. Projects saved before the field was added to `V20260518` came back with `requireGpu === undefined`, which the args lambda rejected and disabled the Run button. The lambda now coerces `undefined → true` (matching the defaults used by `init()` and `upgradeLegacy`) instead of throwing.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -72,7 +72,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     if (data.umap_min_dist === undefined) throw new Error("UMAP min distance is required");
     if (data.cpu === undefined) throw new Error("CPU is required");
     if (data.mem === undefined) throw new Error("Memory is required");
-    if (data.requireGpu === undefined) throw new Error("Require GPU is required");
+    data.requireGpu = data.requireGpu ?? false
 
     // Shared by both modes. The lambda branches on inputMode and returns ONLY the active mode's
     // fields, so a stale off-mode value can't affect the run.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -72,7 +72,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     if (data.umap_min_dist === undefined) throw new Error("UMAP min distance is required");
     if (data.cpu === undefined) throw new Error("CPU is required");
     if (data.mem === undefined) throw new Error("Memory is required");
-    data.requireGpu = data.requireGpu ?? false
+    data.requireGpu = data.requireGpu ?? true;
 
     // Shared by both modes. The lambda branches on inputMode and returns ONLY the active mode's
     // fields, so a stale off-mode value can't affect the run.


### PR DESCRIPTION
## Summary
- `requireGpu` was added to `BlockData` / `V20260518` after that data-model version had already shipped, with no version bump and no migration step.
- Projects saved on an earlier build of `V20260518` therefore come back with `requireGpu === undefined`. `upgradeLegacy` only fires for the pre-V3 shape, and `init()` only runs for fresh blocks, so neither path fills the field for those existing projects.
- The args lambda in `model/src/index.ts` threw on `data.requireGpu === undefined`, which disabled the Run button for any client that had updated to the current main version.
- Default `undefined → true` in the args lambda so the workflow receives a concrete value and the Run button re-enables. `true` matches the defaults used by `init()` (dataModel.ts:52) and `upgradeLegacy` (dataModel.ts:34), so fresh blocks, legacy data, and existing-V20260518 data all converge on the same value.

A cleaner long-term alternative would be to bump the data version and add `.upgradeFrom("V20260518", ...)` that fills `requireGpu: true`, keeping the args lambda strict. That can be a separate change if/when another field needs a migration.

## Test plan
- [ ] Open an existing project created on a build of `V20260518` that predates `requireGpu`. Confirm the Run button is enabled and the run uses GPU (matching the legacy default).
- [ ] Create a fresh block. Confirm `init()`'s `requireGpu: true` default still applies and behavior is unchanged.
- [ ] Toggle `requireGpu` true/false in the UI and confirm the workflow honors both states.