### PR TITLE
Julenmendieta/MILAB-6501_handleHugeInputs

### DIFF
--- a/.changeset/clonotype-space-embedding-streaming.md
+++ b/.changeset/clonotype-space-embedding-streaming.md
@@ -1,0 +1,20 @@
+---
+'@platforma-open/milaboratories.clonotype-space.umap': minor
+'@platforma-open/milaboratories.clonotype-space.workflow': minor
+'@platforma-open/milaboratories.clonotype-space.model': minor
+'@platforma-open/milaboratories.clonotype-space': minor
+---
+
+Embedding mode: stream the embedding matrix instead of eager-loading it, so large inputs no longer OOM.
+
+The `--encoding embedding` path in `main.py` now streams the long-format parquet in fixed 4M-row batches
+rather than materializing the full N×D matrix. The CPU path collects a bounded, seeded fit sample
+(~`--max-sequences` vectors), fits PCA + UMAP on it, then re-streams to project every clonotype in
+batches; the GPU path streams the load straight into VRAM and keeps cuML's fit-on-all behaviour. Peak
+memory is now bounded by the fit sample, independent of the clonotype count.
+
+The workflow passes the embedding length as `--dims` (from the `pl7.app/embedding/length` annotation),
+and the embedding RAM request is lowered to match the streamed footprint. Global exact-duplicate dedup
+is dropped and the fit sample is drawn over all clonotypes; both shift coordinates slightly versus prior
+builds (a memory fix — output already varies across backends and machines). PCA/UMAP parameters and
+sample sizes are unchanged. Sequence-feature mode is untouched.

--- a/.changeset/clonotype-space-embedding-streaming.md
+++ b/.changeset/clonotype-space-embedding-streaming.md
@@ -10,11 +10,13 @@ Embedding mode: stream the embedding matrix instead of eager-loading it, so larg
 The `--encoding embedding` path in `main.py` now streams the long-format parquet in fixed 4M-row batches
 rather than materializing the full N×D matrix. The CPU path collects a bounded, seeded fit sample
 (~`--max-sequences` vectors), fits PCA + UMAP on it, then re-streams to project every clonotype in
-batches; the GPU path streams the load straight into VRAM and keeps cuML's fit-on-all behaviour. Peak
-memory is now bounded by the fit sample, independent of the clonotype count.
+batches, so its peak is bounded by the fit sample, independent of the clonotype count. The GPU path
+streams through cuML IncrementalPCA (partial_fit on ~100k-clonotype batches) so the raw N×D matrix
+never lives in VRAM; its footprint scales with the reduced N×k array and the fit-on-all UMAP, not N×D.
 
 The workflow passes the embedding length as `--dims` (from the `pl7.app/embedding/length` annotation),
-and the embedding RAM request is lowered to match the streamed footprint. Global exact-duplicate dedup
-is dropped and the fit sample is drawn over all clonotypes; both shift coordinates slightly versus prior
+and the embedding RAM request is lowered to match the streamed footprint. The pre-PCA global vector
+dedup is dropped; the GPU path still collapses exact duplicates, but after PCA on the reduced vectors
+(the CPU path does not dedup). The fit sample is drawn over all clonotypes. These shift coordinates slightly versus prior
 builds (a memory fix — output already varies across backends and machines). PCA/UMAP parameters and
 sample sizes are unchanged. Sequence-feature mode is untouched.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -14,7 +14,7 @@ import { blockDataModel } from "./dataModel";
 import { getDefaultBlockLabel } from "./label";
 import type { BlockArgs, BlockData } from "./types";
 
-type Column = PColumn<DataInfo<TreeNodeAccessor> | TreeNodeAccessor | PColumnValues>;
+type Column = PColumn<DataInfo<TreeNodeAccessor> | TreeNodeAccessor | PColumnValues | undefined>;
 
 const inputAnchorSpecs = [
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 1.4.6
       version: 1.4.6
     '@milaboratories/helpers':
-      specifier: 1.14.2
-      version: 1.14.2
+      specifier: 1.14.5
+      version: 1.14.5
     '@milaboratories/multi-sequence-alignment':
       specifier: 1.47.16
       version: 1.47.16
@@ -22,35 +22,35 @@ catalogs:
       specifier: 0.1.2
       version: 0.1.2
     '@milaboratories/ts-builder':
-      specifier: 1.6.0
-      version: 1.6.0
+      specifier: 1.6.1
+      version: 1.6.1
     '@milaboratories/ts-configs':
-      specifier: 1.3.0
-      version: 1.3.0
+      specifier: 1.3.1
+      version: 1.3.1
     '@platforma-open/milaboratories.runenv-python-3':
-      specifier: 1.7.9
-      version: 1.7.9
+      specifier: 1.11.5
+      version: 1.11.5
     '@platforma-sdk/block-tools':
-      specifier: 2.12.0
-      version: 2.12.0
+      specifier: 2.12.9
+      version: 2.12.9
     '@platforma-sdk/model':
-      specifier: 1.79.20
-      version: 1.79.20
+      specifier: 1.80.10
+      version: 1.80.10
     '@platforma-sdk/package-builder':
-      specifier: 3.14.0
-      version: 3.14.0
+      specifier: 3.14.2
+      version: 3.14.2
     '@platforma-sdk/tengo-builder':
-      specifier: 4.0.11
-      version: 4.0.11
+      specifier: 4.0.20
+      version: 4.0.20
     '@platforma-sdk/test':
-      specifier: 1.79.23
-      version: 1.79.23
+      specifier: 1.80.11
+      version: 1.80.11
     '@platforma-sdk/ui-vue':
-      specifier: 1.79.20
-      version: 1.79.20
+      specifier: 1.80.10
+      version: 1.80.10
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.7.0
-      version: 6.7.0
+      specifier: 6.8.2
+      version: 6.8.2
     '@vueuse/core':
       specifier: ^13.3.0
       version: 13.9.0
@@ -89,10 +89,10 @@ importers:
         version: 2.29.8(@types/node@25.0.3)
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.6.1(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.0(@types/node@25.0.3)
+        version: 2.12.9(@types/node@25.0.3)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -107,10 +107,10 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.6.1(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.3.1
       '@platforma-open/milaboratories.clonotype-space.model':
         specifier: workspace:*
         version: link:../model
@@ -122,10 +122,10 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.0(@types/node@25.0.3)
+        version: 2.12.9(@types/node@25.0.3)
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.80.10
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -137,13 +137,13 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.6(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.80.10)(@platforma-sdk/ui-vue@1.80.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.80.10
       '@types/node':
         specifier: '*'
         version: 25.0.3
@@ -153,13 +153,13 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.9.3))(yaml@2.8.2)
+        version: 1.6.1(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.9.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.3.1
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.0(@types/node@25.0.3)
+        version: 2.12.9(@types/node@25.0.3)
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -168,10 +168,10 @@ importers:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
-        version: 1.7.9
+        version: 1.11.5
       '@platforma-sdk/package-builder':
         specifier: 'catalog:'
-        version: 3.14.0
+        version: 3.14.2
 
   test:
     dependencies:
@@ -184,13 +184,13 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.9.3))(yaml@2.8.2)
+        version: 1.6.1(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.9.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.3.1
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.23(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+        version: 1.80.11(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
         version: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
@@ -199,13 +199,13 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.6(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.80.10)(@platforma-sdk/ui-vue@1.80.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.2
+        version: 1.14.5
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.16(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.47.16(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.80.10)(@platforma-sdk/ui-vue@1.80.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -214,10 +214,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.80.10
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+        version: 1.80.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 25.0.3
@@ -233,10 +233,10 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.9.3))(yaml@2.8.2)
+        version: 1.6.1(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.9.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.3.1
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -248,14 +248,14 @@ importers:
         version: link:../software/umap
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.7.0
+        version: 6.8.2
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 4.0.11
+        version: 4.0.20
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.23(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
+        version: 1.80.11(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -1149,8 +1149,11 @@ packages:
   '@milaboratories/biowasm-tools@2.0.3':
     resolution: {integrity: sha512-/X2PJ9VYmVKHZ12X7p2lgzEN+zqeycatVGdVA1ifsdBXE4bKNmCrWhUr4JRlpoB5wuj/J5chBbIi6N9y6Tk1aw==}
 
-  '@milaboratories/computable@2.9.5':
-    resolution: {integrity: sha512-rzLJ6fjXcNL8jb6vexGR4d8wUGvrwC2CyjkMLU5GFy+7Q6lg1wTrJnu8fzDVhS2OjEEVbD+RTE7AGvK5pYYSMQ==}
+  '@milaboratories/columns-collection-driver@0.2.3':
+    resolution: {integrity: sha512-3rNWmuQGvEaBEzGMHIWeOi1p8j8sMDpnPKNUQvT0Ji7/ArvnfM5HK8dywxB+n3mLK8c11lW16+auM5xuydJXGw==}
+
+  '@milaboratories/computable@2.9.8':
+    resolution: {integrity: sha512-X0ZtxOnIJlAd9Y7CyBtWSKHgVuTKXbIryMwJaoYSEz0gY3JZVnsD0f59J/lwe3Key0/lSYh3EbL/pP5jACIzfQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/graph-maker@1.4.6':
@@ -1167,6 +1170,10 @@ packages:
     resolution: {integrity: sha512-nZv+n+orVzA/GimDTNj6Yjb52+Wu5f/Kf2z6UCGXni6KTquLBfQhi3AFB1mLE7hkUYPvKU6LxuRY02CQMQiTVA==}
     engines: {node: '>=22'}
 
+  '@milaboratories/helpers@1.14.5':
+    resolution: {integrity: sha512-Kiy0g7sEmFQxDwtnmTrdJ8XdUK0IDAB5ZnPCNEbK7lPGHIa+xG3kzfeR4y44QBdrYaK0NwG63D8Fc7dlv9KItg==}
+    engines: {node: '>=22'}
+
   '@milaboratories/miplots4@1.2.2':
     resolution: {integrity: sha512-VMdMxfD/lwObssvYDFRnBcBAV4JFqI2FsoQqmJ/wurIHieoZLU9K0UO57MvsvtmO3Deb9swUjuDUJ+jAe8isqw==}
 
@@ -1176,8 +1183,8 @@ packages:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
 
-  '@milaboratories/pf-driver@1.7.14':
-    resolution: {integrity: sha512-JRuMmuhObyD27MtpCcimGklr2yMJ2PobcYJ2y5k+UuhQWXKllhEDlUAyv2Xw/I7Xxym8Nn2npcVdOaJvTP3bPA==}
+  '@milaboratories/pf-driver@1.8.5':
+    resolution: {integrity: sha512-w9GqvYClb7q4BkvHvKeUa8JrcnO/uAN7OrN5aLTs8cmMp5JQGHm13N5KQOQ5I1Tj9slREk+x+QOsRrPO0HQFCA==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pf-plots@1.4.4':
@@ -1186,89 +1193,79 @@ packages:
       '@milaboratories/pl-model-common': 1.39.0
       '@platforma-sdk/model': 1.73.3
 
-  '@milaboratories/pf-spec-driver@1.4.16':
-    resolution: {integrity: sha512-x6SQVUU3fl+1fFavCSzc1DNMB08HKoo0PT5dpXJWAi6oEw77yueoe1StZJVY0Kgj1BpVhlmuuC87PJu8s4eFRw==}
+  '@milaboratories/pf-spec-driver@1.4.24':
+    resolution: {integrity: sha512-ZGDodKhtw8gMIFUU2tFB8SmMmmFX13ywIemJApHQZsDBFNwmXdCQaj2jweKzJkOu+nZMrAi2gTE2dWd1CcfYSg==}
 
-  '@milaboratories/pframes-rs-node@1.1.52':
-    resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
+  '@milaboratories/pframes-rs-node@1.1.56':
+    resolution: {integrity: sha512-H6qltcR+HHb2kAy0U0zP90rqmv/MZGGkdXIyf89FUZTpoHOlXG4Ahxq7wXp9vviUczci4cLl2L0Q+dL2XGcsUA==}
 
-  '@milaboratories/pframes-rs-serv@1.1.52':
-    resolution: {integrity: sha512-yVfcyLztgj5UAffj30se5G4MwxkIOFVWPHY1tZZ8zLhQQzx95R/e1toAqq3FLV7y6kpJovwmLusbefgKw9Ejcg==}
+  '@milaboratories/pframes-rs-serv@1.1.56':
+    resolution: {integrity: sha512-Pi0CRuvkfL+PqdgQ8im0MW5tqVjUvJ8hJbOG7v5pS45adg8tuq4TyrAoWN7un9ZWQ6KRLypUD+7eXCwhjOwADg==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.52':
-    resolution: {integrity: sha512-0rb0We6Q/aqrHJ062dayvLb4RExODZdqfsVWdzeHq23alY5TjJRMWsO9aKQpPnOuUKjAimdjlp+Ldq9TVhbEtg==}
+  '@milaboratories/pframes-rs-wasip2@1.1.56':
+    resolution: {integrity: sha512-54bhC6XCAVO09J/sqVwEKA4hhTa27BDDNdH8BE+6+LvjBVkg/qq2/f0MzdrVijrmagbr97F1zgj5wIgUqwCSoA==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.52':
-    resolution: {integrity: sha512-Wn8/LJxcsvWSSpdymdebWrBnmgu9wAbzvOiHCtXz7Aqt1M2T8Xp9a7CprzCYx+EvhSuAuoxbq6naxkPsQrbkvg==}
+  '@milaboratories/pframes-rs-wasm@1.1.56':
+    resolution: {integrity: sha512-k/RQqiF+SwoOtFnYQ+i34Lzna8prOoFbLHaPY5oEUOrB/czehosFMzRQJAeFDKOxI/SbrH4D5jmWzTgUuhavLQ==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.46.2
       '@milaboratories/pl-model-middle-layer': 1.30.7
 
-  '@milaboratories/pl-client@3.12.0':
-    resolution: {integrity: sha512-uca6tbW7hy7H/Sf010/9HNQMFKwf6bJ/JONyNgvQB+hGdJZb//vjw0xoBQDun0wSAkPm+9H2I+e0q6RUfcNZng==}
+  '@milaboratories/pl-client@3.14.4':
+    resolution: {integrity: sha512-LljKMbKa8zl2lNFkg3VthMx9E6308B5vSH7dtWnlVz20ZU1GF7steToGv5gWs1lwUtm4GRU7kmmsMzU9a7l2yg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-client@3.13.2':
-    resolution: {integrity: sha512-5sx6ehEPfo7q4ojyXgPgQIzn4iPZs7YPvEPctRkwQ6cuK5KzLO059FjzUjsJDh5Si7QbUL/yi5qxCf1h1q4G6g==}
+  '@milaboratories/pl-config@1.8.5':
+    resolution: {integrity: sha512-XnfYXSSkRxeImQ21k6I8y5apisvagcSgMGfEeyRxNdSGwUVJbbI8TwJk+XBEDQ4lErW8oqtLxKjFQuHJMzRUoQ==}
+
+  '@milaboratories/pl-deployments@3.0.14':
+    resolution: {integrity: sha512-ltkbSlNf7kIHxZ5SG0L7MVxlGa2NKwjN051NzJ6mF0DsWVpn6kcSz1usIsmpJnK7F7xprDKDgVD/YbtMJipy+A==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-config@1.8.2':
-    resolution: {integrity: sha512-FG9rlAKDf1rwlg+3G9OG2bCKISNp6ajM27W7ODDSsWE4MSCVxhYB172UusbohY2RDmaD9GI5pDKO5O9uoHQCCA==}
-
-  '@milaboratories/pl-deployments@3.0.8':
-    resolution: {integrity: sha512-7WvA761yI7eLCdJE19uNa/a6fLxytVrKJ/utBJ6GelZQFuA/LT12VkG6r0uAFtU8afY9Sr89078oLzZSZJR/oA==}
-    engines: {node: '>=22.19.0'}
-
-  '@milaboratories/pl-drivers@1.16.3':
-    resolution: {integrity: sha512-/HObfG0uuFDYUd8G3qxlhrvhvTo8T5MH42+Vpr8snN+YnSHGyMXo6rw6oKRNO+h/GF+kbI5DTr9kNsQVEwyFng==}
+  '@milaboratories/pl-drivers@1.16.12':
+    resolution: {integrity: sha512-sIk57/rDhTf8Yy+ajM77+xIWLLlb36UsqduCz4bmxTSn81Ll77dGvowv0Vt606horkDMGcnZ9gs/78Hgpjb3qQ==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-errors@1.4.24':
-    resolution: {integrity: sha512-pV0oF0zO6bwAo/llQlu4Q00uI0guPQ9Wn+coK3pwLrateKidVRH/2XhwUgTwgS8vDECBNCgtYR6E/Im+nl+FMw==}
+  '@milaboratories/pl-errors@1.4.33':
+    resolution: {integrity: sha512-ijKj4jMJlWzihOWLq6Q/HWfFhMyuRY5hmnR/HzlHNf/tjhKa5/yCx2H9V5HduH81xORgPSRceTrDUZy1cqXwTQ==}
 
-  '@milaboratories/pl-healthcheck@1.0.1':
-    resolution: {integrity: sha512-eiYd/TFm18SW4EY8vkI3c+fcPnjUu3Hd1GnPLWCN8U+dNmp/tnrzfeCgaY4xO/s0vkHNX9E7IrsQiMg2Ioz4rw==}
+  '@milaboratories/pl-healthcheck@1.0.4':
+    resolution: {integrity: sha512-VLoF7iW7px8BG+vTT/nQ+qkJDNSsXUivRsyZlbM7VCxKdVrZwPfn/rqQIJ4g6daBONVtCqUhAFi52IeXRg5mxg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.64.41':
-    resolution: {integrity: sha512-6xXwmTaaImd6HQ2PZgUWGf1gXsfgEPz3zWQsmaUaPMyMusjPVynPCX2hnThqrPVf54mEMlvc3HTGaC+dofDF0g==}
+  '@milaboratories/pl-middle-layer@1.66.10':
+    resolution: {integrity: sha512-fDjfD1mp6T6gkMfLClWJUd6ld8UjcrFy3x3F/aZnjbZ8mwdH2nLkO7DoVsS+5+8/8+QB5XaMK1UJh/wJOQhBKw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.4.13':
-    resolution: {integrity: sha512-HGEVDZXh/XUU5sDuBB46pMc1+46elzvrPuKCaowhqpzBPzA4j/DNxuJucJRv/h/oE0Ue3kEQf+6x0506kGDrow==}
-
-  '@milaboratories/pl-model-backend@1.4.9':
-    resolution: {integrity: sha512-84+Pv2RhonE/ZwR5bXipOGK4cC5V3C4vmhzIgc8TWpgLxUNsjCjoodSo3bzPcpA+URShTf4+3h4C28O/wO/MCw==}
+  '@milaboratories/pl-model-backend@1.4.18':
+    resolution: {integrity: sha512-cDSreI5DV25v9JmiRDMdp8c2+ZxJgeIjnybsuToVbBwDHoANFqB+2Nsxos5jzU2nxCx5kt2KYJw9/tweuSC4xQ==}
 
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
-  '@milaboratories/pl-model-common@1.46.4':
-    resolution: {integrity: sha512-QArgLyQkf8kHSQquxStyk5Xfnau8S4M2vKEbUVQRRoZCzLU1lcDVXRwGgAzRH5NizeqYNrB/wt0/tShajH+6eA==}
+  '@milaboratories/pl-model-common@1.47.3':
+    resolution: {integrity: sha512-tXmKujm+6ru/Fh9hr9H3iRBWbS+JE0Q7FNualtzJpijaB3SNtScR4erLTamdANv5RYNn7kbYpDWr6wAjAOajrg==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.11':
-    resolution: {integrity: sha512-yFThwVqOTb2gJw/tp4PkZcsKI7yRRJCX3QuA6fIc2+tNxCqyEQmdpLmaIY/nhaziIp9ByBT9MrzWNIQd1T9aww==}
+  '@milaboratories/pl-model-middle-layer@1.30.15':
+    resolution: {integrity: sha512-oBkVlKR+qgsQR74N8G3aW3wBaJw78+9HJjnaNbH7QrTjKq4pno7wTXdrz7Ptk6Tu4SWfkcecXY6+xCnkDKr4eQ==}
 
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.9':
-    resolution: {integrity: sha512-fnrCjWPR0HeytWC3rnHkY3bpNk3UOuED+lwmauhYBKRaF46cV1df46clJSkGNZHS9g439SYwclW4no2X/ALaFQ==}
-
-  '@milaboratories/pl-tree@1.12.14':
-    resolution: {integrity: sha512-G6uUG+3b4rH0eEQP6B31unFJtxsutETJckvapqXd9u+Uo906mK4w5u6DnXcNWfhWhKx3/hp8v89CsYSDO3b7Qw==}
+  '@milaboratories/pl-tree@1.13.3':
+    resolution: {integrity: sha512-39QT6opCX4ejjT0UI7dq4HMEs/NBXEI2nQyyaHbJBLKGKr6DKhUAUd0mLqeIjsEdH0B4eo3bKMlgry5PaPSlpQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ptabler-expression-js@1.2.31':
-    resolution: {integrity: sha512-VB3fxuVqc0Beb+3/ge9uZ39uU8YqAhck9pTIxTpNZ5hOfMtPGJEI98YxoJQ8BuYhyyx5SM5qMU04NNs/vdk46A==}
+  '@milaboratories/ptabler-expression-js@1.2.37':
+    resolution: {integrity: sha512-urVRk4b5Jse555euNNITlOJ437McZVtBnC5h/E6O+iHm+hfNIi6OP1aAD5ai4jOpHllm85zW5Ne7hVyyd71bJw==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1284,29 +1281,19 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
-  '@milaboratories/ts-builder@1.6.0':
-    resolution: {integrity: sha512-OlQ38jsriFf7qS5AmNIch65qQAOZBRFaLT15N/JJqe9dIytKJNS8Ff9G4vowWtFiRzyeyWRArBtgVOeAmoYuKQ==}
+  '@milaboratories/ts-builder@1.6.1':
+    resolution: {integrity: sha512-0m+I8bdxw6mGTfPt+xW8OGvburrxLUpI/QZsyACHsXwyfVRfDKvWB3/9Hm053KzwHqrzpeuvidEBdKRVRAi9KQ==}
     hasBin: true
 
-  '@milaboratories/ts-configs@1.3.0':
-    resolution: {integrity: sha512-6rZaMOJotG+v6eXoupHgPqxArpNBNl0f7sd5K+kUo1PUhPTe632eLJtEeBbFtwDGNYqL9QUacd4pT5t6oDOf0A==}
+  '@milaboratories/ts-configs@1.3.1':
+    resolution: {integrity: sha512-MfLF+qgDwnD2BuncGzFqQxKuqq/0KtXcXXftcvp8E08xY9cl5kkmBHX/H8RYAH4FvF6ghb56c3I6iaxIa5xIUw==}
 
-  '@milaboratories/ts-helpers@1.8.3':
-    resolution: {integrity: sha512-HK3AmNZl2fOzMHot2+ihKsOC+fluwhl5261VTn1zGS3LRpmC9bCk/po8SzsVmg79ccI5nESFTdz+BRaLsXncmQ==}
+  '@milaboratories/ts-helpers@1.8.6':
+    resolution: {integrity: sha512-ef01tARUl+0Urt3x8HHAByrhYHg4Rnn7WiFyJ+joZFZl1T1pUKTgfB7Zxc8Cn06HIl4i6H7s5OSymjZePIGqfQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ts-helpers@1.8.4':
-    resolution: {integrity: sha512-YdOyANkJjFiEZgS3bfbludDo9PWOQZQ8AhGw/rpO5/7bgQ9RIVOOTAtP5/UppANoeUiYhCgJt/xvIZgnQ/PZ0w==}
-    engines: {node: '>=22.19.0'}
-
-  '@milaboratories/uikit@2.15.11':
-    resolution: {integrity: sha512-oBQiPXpHEwg1dLptfCQNtpRrJ3stunjrTWiP5U90rAXl4c6Z/Ks7YU/fVvoqdBsoSBQ6nEcAG0Sk4sV8DVRlJQ==}
-
-  '@napi-rs/wasm-runtime@1.1.3':
-    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+  '@milaboratories/uikit@2.15.18':
+    resolution: {integrity: sha512-PUxUKDdR7KW5+Bb2NQFD+9u4oNIzusSK1VkCiyfDJ/4B0TxpUG1Fi8mJgCHZMtmTqMZ4d7V7zBuFPQsI9+xg4Q==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1609,41 +1596,50 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-atls@1.2.4':
-    resolution: {integrity: sha512-yeklY7ISewNOQ5TWlNLRi6VSOGfcdTJPoDWtf5Z8na3xPP56fWZFuckX/ixZpGvcoyBSQf1kFBFnHPginX7jCw==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-atls@1.2.7':
+    resolution: {integrity: sha512-vJiU68NKgyupW5meeWB/pZZ8y5wewPV6/EcRQ2BwUhSyikDQrn83XzBlc/nTu9UmbYmBqQTrt59x0qKtcC0ILw==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.4':
-    resolution: {integrity: sha512-Yo47x/rm/FF8x/7q2o7TXdAS7pEWqBd/+aHnQzgNAF0DYljzln99mq1L4lMrQx08SJBGrh84ZtgQl/weTzWSIw==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-clustering@0.1.1':
+    resolution: {integrity: sha512-hnr1tf0dwoqTyjtUVZcwQm13O0V8kz4jCUz+yvOgdvWMrbg4o/h1KbghtM8HivI+tRoowc629QJWdy0bc7inQA==}
+
+  '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.5':
+    resolution: {integrity: sha512-cuGk6NMBocvNePoMTnDW4z8eIF5RQdDcgwuPHg9atW9/veOOp02p5jk0EwxmnbMSVV0yDwRMd+0crQAQqW9bCA==}
+
+  '@platforma-open/milaboratories.runenv-python-3.12.10-humanness@0.2.0':
+    resolution: {integrity: sha512-YjKFPXe+caABLre5oZTwAxFHvVCEb5K8rVTEIUBhFYMtfLipVIix0LXi6LxWoOYdhoEeKgIc4zlWFDKs1xaEoQ==}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-parapred@1.1.0':
     resolution: {integrity: sha512-nEM4eEj7pFT6yi+P5028qtgK5v9A9H0XdVHDtrKX7xW5Jipc1RIliOEU3gzaH0E7UAzPFQGSqShlwakRcGXwdQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.5.0':
-    resolution: {integrity: sha512-TA/9q+fVKjyVLLeSkhLMFqIpPn4B46SQVMBna+INYsvpKUtu0GPQrJ9WES2Q+Dxpi0FivzsiN30h8z5ZQBQ/2Q==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-pgen@0.2.0':
+    resolution: {integrity: sha512-+4pEVwRZaBAm0716NoNdK9cfF4E7jtsRUpcAWYCuPbbZJ3Q7bgfgq8bEhcck8No97l9jWN2rAeJegA9UQy5FgQ==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda@1.3.5':
-    resolution: {integrity: sha512-oNkt0u8fgZACcL3XmAu4v0tDGnTSc3qRQs07U8OFX+paQk7qH4ckt0psLGN1iHDKZ3Gw3nlgel0D6Lst02WahQ==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.7.1':
+    resolution: {integrity: sha512-qYbJTZtRzGp97Kil28n62geQbQPJDa3lNJO8FqsiOCCpfXuCExKUyzx0f8VcUdCki5GmUArXpicJm8R/iNAl8A==}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.6':
-    resolution: {integrity: sha512-Bv4IF0PtbnyKJmlW/ygcGdhJS3cSCsOFZWR9buzr+VteDITKS1xyISW6tkO3glVBgInITGrtaDPKXTeiurhOHA==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda@1.3.6':
+    resolution: {integrity: sha512-NAacPe2uFxf5zqDAa70bblP4ZicvA52lVyzhV7IzlyeEIClAsGatLbitMnRghc2TepwYhQY4EbvElkKDFaSSGw==}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.7.9':
-    resolution: {integrity: sha512-erlYStN9cZ97tvzm5C+yBq46mjeXp9T0QhuhEI03a/HA4R296o0QFMr9opim5/CS3BpdWf++QJJtqqypOYdaKw==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.1.0':
+    resolution: {integrity: sha512-CSLEjBYUdHDf66QAfgQ9jo+MoW63Wr0ygdIncJE2siO2jMUzYCqgCNd8bMjaMfZa3YBC9bHca3Cjxbp4VYc54A==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.15':
-    resolution: {integrity: sha512-zvPuRZgQyxjED+txJVgWHUOPeRp4TG1jOrJOtuw9WnwxFiHNjQHIB+Xe1j8f6skgMqZgRSQvEbhRvqbWjGmhKQ==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.2.0':
+    resolution: {integrity: sha512-PRGkgsVY08tQvoucU8fJmeCF+x9XjiHHjNTbxWqddqx2EZpiUvmylkxtU8i8xJW13cesAI+xHv3NsVUXQaRDqA==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.3':
-    resolution: {integrity: sha512-4cikdkdJ5WYc0Nw3IoZxzlFNKvG1qCAqSjypq5b18pIK6LBDayzhFcuw5TDd8O3bAFhoHP+3cVTmoO9XUTYMRg==}
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.24':
+    resolution: {integrity: sha512-5ne8Fmlhu1YKB5RYgq4c/AvYzb+sUY4hzv/bKIj0E3aDgJdMYO6M6lMicDzQTMagrGRu9FIhDewIgo++TX3+Yw==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.4':
-    resolution: {integrity: sha512-hLGDR7xVKoKj+4IM+fiWmJjFvYCZ2JmDQ7/Z99nq1zglAJJ1dqqVrtZ2TJ67HNyORpe1CrkRXvP9kNc4JxBUgA==}
+  '@platforma-open/milaboratories.runenv-python-3@1.11.5':
+    resolution: {integrity: sha512-Xy73J7CTRNdAu+bjzsZDwki3hpIpDDWJXcmY3HloTQtx6FXvzyOH5zi2OI6DPMB2qQn3tJMQZctuF0JR0y+yYw==}
 
-  '@platforma-open/milaboratories.software-ptexter@1.2.2':
-    resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.21':
+    resolution: {integrity: sha512-3EWO64poe5VcBIgVIdIFHwN7nPi000kPuaRmlVt3xnnQZqXUYDFNZfZ2Mc9/mE1Eq3FLwQxcy/5mng7LvgWnXg==}
 
-  '@platforma-open/milaboratories.software-ptexter@1.2.3':
-    resolution: {integrity: sha512-5wwzvPko/tjkm6EnirsnjB+MO5mF//tgJplI+jPh3bcSHpEdHF+B9xg+S1owAnekqbimMrFZWqHSVY9ZmIHOjw==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.8':
+    resolution: {integrity: sha512-28dKwcKNIB/8OYH6l/li7Qa/aE2NgDVtNUmN8v6jZsLKT59ogFclz8ZrQ+OiQFzHQCLBlWBt5TdIHfHPxBaNFw==}
+
+  '@platforma-open/milaboratories.software-ptexter@1.2.4':
+    resolution: {integrity: sha512-4ZqhqksSNVKWhEB9WwrL0rU89G+00ulzH1urYyNA4EdBVGA4mwbKbw0K/zcwce/oUYYMdRl+epXmr0w9wHyNzA==}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10':
     resolution: {integrity: sha512-16BGRLIrsVW+YIaXwWLX6Nbm80PS5mQJEclHhjNbRrRTLHPaKI4RygZfBC0lLNzvHBiTXU4Qkh1+WmdovkshDg==}
@@ -1663,47 +1659,37 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
-  '@platforma-sdk/block-tools@2.11.6':
-    resolution: {integrity: sha512-CyekNfqEildNeTrkjAeaWC7ah+skGMb3d/crSZSgCWACPIVQwg2oRZiJliwmJU/ylcTONPDAef7DYOtmfXsgtw==}
-    hasBin: true
-
-  '@platforma-sdk/block-tools@2.12.0':
-    resolution: {integrity: sha512-G6HcBp2tmwSoFuouxYHmHWFDkjc2DYd+zZreFoQTt4+IAlzQ2pyE8RBbB9edtN7/nKKCLuljBkg3Gcn1htzZbw==}
+  '@platforma-sdk/block-tools@2.12.9':
+    resolution: {integrity: sha512-wtqkPsjMpan+XjP0GHa8pcJbj3CX0Jmzxjxez0sz+jGMiIqpsNV3sSTQGYj1zkgYA9Wi0lusKiNoVOYB7Jtmbw==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
-  '@platforma-sdk/model@1.79.20':
-    resolution: {integrity: sha512-0ULETzwgo4E5rIddn/PoCAY5gSv9luDYAaSp66b8u3u1XTh43k7fgOpobu/rrfHJMiY9IGfzALDlo6jtvMLUyQ==}
+  '@platforma-sdk/model@1.80.10':
+    resolution: {integrity: sha512-M9a2yuiYmov4Xv0yMArkl4SJ591vOSccSRWMK8KV0fH098PJiS2ailmaIqS4KfL2WYh2hoe7ceCaVlpHHf+JWg==}
 
-  '@platforma-sdk/package-builder-lib@1.1.0':
-    resolution: {integrity: sha512-h/Hx4Fg+kGnX2sVPWJa48JHbSEofTnaOescTKBP1Py5wl3A68BjqKaI6yybLWSR5Ojp3tHNNlvFSAnoF2QYMMg==}
+  '@platforma-sdk/package-builder-lib@1.2.1':
+    resolution: {integrity: sha512-H6weitj7JxbiJSlteEFLafTJ+tfty6iv/imf3ysy8oCS8AZIRJk2VMW3M/aAc+xVkQeX7oVIwMwFMYrJIoFsAg==}
 
-  '@platforma-sdk/package-builder-lib@1.2.0':
-    resolution: {integrity: sha512-AtSzaZ39BGlqcyYtpGREDz+YlGCDdSTQJNV/+NkTyUtoq1ECRO+iMqAX1DSSza1WqylnURX8vKVI2owS/cxntA==}
-
-  '@platforma-sdk/package-builder@3.14.0':
-    resolution: {integrity: sha512-7bRducsc9NLc1zo0GRfz3RHSTejxFfmFvr21EH8NBndGaCj5KvHt2+0jmQsSI1Sl7ZCaj+zQKWWukRlsi+b/uA==}
+  '@platforma-sdk/package-builder@3.14.2':
+    resolution: {integrity: sha512-EtI6VRIJdmiexse4nNjyajD2wuzt0xwyS8snl/XSbHamdCIFtkyckbAeBCtjaCqmoislzOMIMGQYegw3cxfZXA==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@4.0.11':
-    resolution: {integrity: sha512-c0LuiR7vtclto853Q1O+j8g109ooIZKtEl5tqRHG6dN/kk6S+J7DZHCpAjFuZ9pt3x6jF95sNaJEtP8uFs1uXw==}
+  '@platforma-sdk/tengo-builder@4.0.20':
+    resolution: {integrity: sha512-4zf38sLzctOgbwym39+YdrE07/W61zzNaeZebZd0p2QDYNacAf83hRlD5KlDvUZtrDbhYNMgoZtghw61XAchog==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.79.23':
-    resolution: {integrity: sha512-vb5K4Rtjy5ogom3fBYpOxvKL+Nb50iURUdd1vjzN3pcQGx47omBnDr9YvNvUsRC3INhZibLzy44dUKD2la/IMw==}
+  '@platforma-sdk/test@1.80.11':
+    resolution: {integrity: sha512-6AjBpc7UjvT3DFXAtHseBgu0DF8q2AHPThwibxPTGY/fbmhfph3ulEilyRjHIrEre2v3oiud1a65RhrkGCKIQA==}
 
-  '@platforma-sdk/ui-vue@1.79.20':
-    resolution: {integrity: sha512-VwBG8MKV1M2KMR2PgW+o6uxJJRCFGihaRsnkzLL8HGKM/Vr9k3FY/V929B1XAhU5y9wb1g7fKNJvy9JNEq5GiQ==}
+  '@platforma-sdk/ui-vue@1.80.10':
+    resolution: {integrity: sha512-nwBVD/NMGBn2aRpOylIx2/acPpsE1sTLXcQBYsAoQJ35J8ah3fDuA4AmUvqGHemZNPYo59tNXRhk5mAd6vlWwg==}
 
-  '@platforma-sdk/workflow-tengo@6.6.5':
-    resolution: {integrity: sha512-BIY0DongPruQ7e2EMYy2b0UtO5ziGcLvr2RWgJ8ki17VKNzW3esm/RBszGHMrTYmXM0Yw7mCSasor4vH560g7A==}
-
-  '@platforma-sdk/workflow-tengo@6.7.0':
-    resolution: {integrity: sha512-hotcGbt42gbMRpNp4PEtE8TBLAQXn+V2LM1SCyY5cnc+tWXxUwhgQnfNsg/xOvbu2qxUZhVrGisvb7Ruj+L2IA==}
+  '@platforma-sdk/workflow-tengo@6.8.2':
+    resolution: {integrity: sha512-AHR/Y+vbyfda17A7xY2uH9TlXiBpM8242tTO6+lj8phA4/KS6mez4GLu4ZEaASlZpX6YkQsUs5LUxYQU7pXeiQ==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -3760,9 +3746,6 @@ packages:
     resolution: {integrity: sha512-RLGFxPNgY9AtVVrFGdKO6Y3pOd/Ov2WA4O2/czZN/AbgYzbPdoF0KkfvHRIney6k+TtvoyYB8YqZXJ4G88f9BQ==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -7793,45 +7776,26 @@ snapshots:
 
   '@milaboratories/biowasm-tools@2.0.3': {}
 
-  '@milaboratories/computable@2.9.5':
+  '@milaboratories/columns-collection-driver@0.2.3':
+    dependencies:
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pl-model-common': 1.47.3
+
+  '@milaboratories/computable@2.9.8':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.6
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.80.10)(@platforma-sdk/ui-vue@1.80.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.9
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)
-      '@platforma-sdk/model': 1.79.20
-      '@platforma-sdk/ui-vue': 1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
-      '@types/d3-hierarchy': 3.1.7
-      '@types/d3-scale': 4.0.9
-      '@vueuse/core': 13.9.0(vue@3.5.26(typescript@5.9.3))
-      ag-grid-vue3: 34.1.2(vue@3.5.26(typescript@5.9.3))
-      canonicalize: 2.1.0
-      d3-hierarchy: 3.1.2
-      d3-scale: 4.0.2
-      vue: 3.5.26(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@milaboratories/pl-model-common'
-      - d3-dispatch
-      - d3-path
-      - d3-scale-chromatic
-      - supports-color
-      - typescript
-
-  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
-    dependencies:
-      '@ag-grid-community/core': 32.3.9
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.20)
-      '@platforma-sdk/model': 1.79.20
-      '@platforma-sdk/ui-vue': 1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.80.10)
+      '@platforma-sdk/model': 1.80.10
+      '@platforma-sdk/ui-vue': 1.80.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.9.0(vue@3.5.26(typescript@5.9.3))
@@ -7851,6 +7815,8 @@ snapshots:
   '@milaboratories/helpers@1.14.2': {}
 
   '@milaboratories/helpers@1.14.3': {}
+
+  '@milaboratories/helpers@1.14.5': {}
 
   '@milaboratories/miplots4@1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
@@ -7890,13 +7856,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.16(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.16(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.80.10)(@platforma-sdk/ui-vue@1.80.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.3
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)
-      '@platforma-sdk/model': 1.79.20
-      '@platforma-sdk/ui-vue': 1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.80.10)
+      '@platforma-sdk/model': 1.80.10
+      '@platforma-sdk/ui-vue': 1.80.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       vue: 3.5.26(typescript@5.9.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -7906,14 +7872,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/pf-driver@1.7.14(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.8.5(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pframes-rs-node': 1.1.56
+      '@milaboratories/pframes-rs-wasm': 1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.3)(@milaboratories/pl-model-middle-layer@1.30.15)
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/pl-model-middle-layer': 1.30.15
+      '@milaboratories/ts-helpers': 1.8.6
       es-toolkit: 1.43.0
       lru-cache: 11.2.4
     transitivePeerDependencies:
@@ -7921,44 +7887,36 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)':
+  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.80.10)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.2
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-model-common': 1.47.3
+      '@platforma-sdk/model': 1.80.10
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.20)':
+  '@milaboratories/pf-spec-driver@1.4.24(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.4
-      '@platforma-sdk/model': 1.79.20
-      canonicalize: 2.1.0
-      lodash: 4.17.21
-
-  '@milaboratories/pf-spec-driver@1.4.16(@bytecodealliance/preview2-shim@0.17.8)':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pframes-rs-wasm': 1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.3)(@milaboratories/pl-model-middle-layer@1.30.15)
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/pl-model-middle-layer': 1.30.15
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-node@1.1.52':
+  '@milaboratories/pframes-rs-node@1.1.56':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.52
+      '@milaboratories/pframes-rs-serv': 1.1.56
       '@milaboratories/pl-model-common': 1.46.2
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.52':
+  '@milaboratories/pframes-rs-serv@1.1.56':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.2
@@ -7967,21 +7925,21 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.52': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.56': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)':
+  '@milaboratories/pframes-rs-wasm@1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.3)(@milaboratories/pl-model-middle-layer@1.30.15)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.52
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
+      '@milaboratories/pframes-rs-wasip2': 1.1.56
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/pl-model-middle-layer': 1.30.15
 
-  '@milaboratories/pl-client@3.12.0':
+  '@milaboratories/pl-client@3.14.4':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/ts-helpers': 1.8.6
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -7994,37 +7952,19 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.2
 
-  '@milaboratories/pl-client@3.13.2':
+  '@milaboratories/pl-config@1.8.5':
     dependencies:
-      '@grpc/grpc-js': 1.13.4
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/ts-helpers': 1.8.4
-      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
-      '@protobuf-ts/runtime': 2.11.1
-      '@protobuf-ts/runtime-rpc': 2.11.1
-      canonicalize: 2.1.0
-      denque: 2.1.0
-      long: 5.3.2
-      lru-cache: 11.2.4
-      openapi-fetch: 0.15.0
-      undici: 7.16.0
-      utility-types: 3.11.0
-      yaml: 2.8.2
-
-  '@milaboratories/pl-config@1.8.2':
-    dependencies:
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.6
       upath: 2.0.1
       yaml: 2.8.2
 
-  '@milaboratories/pl-deployments@3.0.8':
+  '@milaboratories/pl-deployments@3.0.14':
     dependencies:
-      '@milaboratories/pl-config': 1.8.2
-      '@milaboratories/pl-healthcheck': 1.0.1
+      '@milaboratories/pl-config': 1.8.5
+      '@milaboratories/pl-healthcheck': 1.0.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/ts-helpers': 1.8.6
       decompress: 4.2.1
       ssh2: 1.17.0
       tar: 7.5.2
@@ -8033,15 +7973,15 @@ snapshots:
       yaml: 2.8.2
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.16.3':
+  '@milaboratories/pl-drivers@1.16.12':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-tree': 1.12.14
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/computable': 2.9.8
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pl-client': 3.14.4
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/pl-tree': 1.13.3
+      '@milaboratories/ts-helpers': 1.8.6
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
@@ -8064,16 +8004,16 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-errors@1.4.24':
+  '@milaboratories/pl-errors@1.4.33':
     dependencies:
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pl-client': 3.14.4
+      '@milaboratories/ts-helpers': 1.8.6
       zod: 3.25.76
 
-  '@milaboratories/pl-healthcheck@1.0.1':
+  '@milaboratories/pl-healthcheck@1.0.4':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.6
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -8082,28 +8022,29 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.64.41(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)':
+  '@milaboratories/pl-middle-layer@1.66.10(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)':
     dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pf-driver': 1.7.14(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.4.16(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-deployments': 3.0.8
-      '@milaboratories/pl-drivers': 1.16.3
-      '@milaboratories/pl-errors': 1.4.24
+      '@milaboratories/columns-collection-driver': 0.2.3
+      '@milaboratories/computable': 2.9.8
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pf-driver': 1.8.5(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.4.24(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pframes-rs-node': 1.1.56
+      '@milaboratories/pframes-rs-wasm': 1.1.56(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.3)(@milaboratories/pl-model-middle-layer@1.30.15)
+      '@milaboratories/pl-client': 3.14.4
+      '@milaboratories/pl-deployments': 3.0.14
+      '@milaboratories/pl-drivers': 1.16.12
+      '@milaboratories/pl-errors': 1.4.33
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.9
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/pl-tree': 1.12.14
+      '@milaboratories/pl-model-backend': 1.4.18
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/pl-model-middle-layer': 1.30.15
+      '@milaboratories/pl-tree': 1.13.3
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.3
-      '@platforma-sdk/block-tools': 2.11.6(@types/node@25.0.3)
-      '@platforma-sdk/model': 1.79.20
-      '@platforma-sdk/workflow-tengo': 6.6.5
+      '@milaboratories/ts-helpers': 1.8.6
+      '@platforma-sdk/block-tools': 2.12.9(@types/node@25.0.3)
+      '@platforma-sdk/model': 1.80.10
+      '@platforma-sdk/workflow-tengo': 6.8.2
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.43.0
@@ -8124,15 +8065,9 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.4.13':
+  '@milaboratories/pl-model-backend@1.4.18':
     dependencies:
-      '@milaboratories/pl-client': 3.13.2
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-backend@1.4.9':
-    dependencies:
-      '@milaboratories/pl-client': 3.12.0
+      '@milaboratories/pl-client': 3.14.4
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -8143,17 +8078,18 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.46.4':
+  '@milaboratories/pl-model-common@1.47.3':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/helpers': 1.14.5
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
+      es-toolkit: 1.43.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.11':
+  '@milaboratories/pl-model-middle-layer@1.30.15':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pl-model-common': 1.47.3
       es-toolkit: 1.43.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -8166,27 +8102,19 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.9':
+  '@milaboratories/pl-tree@1.13.3':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.2
-      es-toolkit: 1.43.0
-      utility-types: 3.11.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-tree@1.12.14':
-    dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-errors': 1.4.24
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/computable': 2.9.8
+      '@milaboratories/pl-client': 3.14.4
+      '@milaboratories/pl-errors': 1.4.33
+      '@milaboratories/ts-helpers': 1.8.6
       denque: 2.1.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.2.31':
+  '@milaboratories/ptabler-expression-js@1.2.37':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.15
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.21
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -8196,9 +8124,9 @@ snapshots:
 
   '@milaboratories/tengo-tester@1.6.4': {}
 
-  '@milaboratories/ts-builder@1.6.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.9.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.6.1(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.24(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
-      '@milaboratories/ts-configs': 1.3.0
+      '@milaboratories/ts-configs': 1.3.1
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.24(typescript@5.9.3))
       commander: 15.0.0
       jsonc-parser: 3.3.1
@@ -8237,9 +8165,9 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-builder@1.6.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.6.1(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)':
     dependencies:
-      '@milaboratories/ts-configs': 1.3.0
+      '@milaboratories/ts-configs': 1.3.1
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.26(typescript@5.6.3))
       commander: 15.0.0
       jsonc-parser: 3.3.1
@@ -8278,9 +8206,9 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-builder@1.6.0(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.9.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.6.1(@types/node@25.0.3)(esbuild@0.27.2)(rollup@4.55.1)(vue@3.5.26(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
-      '@milaboratories/ts-configs': 1.3.0
+      '@milaboratories/ts-configs': 1.3.1
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))
       commander: 15.0.0
       jsonc-parser: 3.3.1
@@ -8319,24 +8247,18 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-configs@1.3.0': {}
+  '@milaboratories/ts-configs@1.3.1': {}
 
-  '@milaboratories/ts-helpers@1.8.3':
+  '@milaboratories/ts-helpers@1.8.6':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.5
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/ts-helpers@1.8.4':
+  '@milaboratories/uikit@2.15.18(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
-      canonicalize: 2.1.0
-      denque: 2.1.0
-
-  '@milaboratories/uikit@2.15.11(typescript@5.9.3)':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/helpers': 1.14.5
+      '@platforma-sdk/model': 1.80.10
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8367,17 +8289,17 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
-    dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -8610,38 +8532,49 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-atls@1.2.4': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-atls@1.2.7': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.4': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-clustering@0.1.1': {}
+
+  '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad@1.1.5': {}
+
+  '@platforma-open/milaboratories.runenv-python-3.12.10-humanness@0.2.0': {}
 
   '@platforma-open/milaboratories.runenv-python-3.12.10-parapred@1.1.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.5.0': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-pgen@0.2.0': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda@1.3.5': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-rapids@1.7.1': {}
 
-  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.6': {}
+  '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda@1.3.6': {}
 
-  '@platforma-open/milaboratories.runenv-python-3@1.7.9':
+  '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim@1.1.0': {}
+
+  '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda@0.2.0': {}
+
+  '@platforma-open/milaboratories.runenv-python-3.12.10@1.3.24': {}
+
+  '@platforma-open/milaboratories.runenv-python-3@1.11.5':
     dependencies:
-      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.6
-      '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.4
-      '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.4
+      '@platforma-open/milaboratories.runenv-python-3.12.10': 1.3.24
+      '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.2.7
+      '@platforma-open/milaboratories.runenv-python-3.12.10-clustering': 0.1.1
+      '@platforma-open/milaboratories.runenv-python-3.12.10-h5ad': 1.1.5
+      '@platforma-open/milaboratories.runenv-python-3.12.10-humanness': 0.2.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-parapred': 1.1.0
-      '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.5.0
-      '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.5
+      '@platforma-open/milaboratories.runenv-python-3.12.10-pgen': 0.2.0
+      '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.7.1
+      '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.6
+      '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim': 1.1.0
+      '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda': 0.2.0
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.15':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.21':
     dependencies:
-      '@milaboratories/pl-model-common': 1.46.2
+      '@milaboratories/pl-model-common': 1.47.3
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.3': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.8': {}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.4': {}
-
-  '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
-
-  '@platforma-open/milaboratories.software-ptexter@1.2.3': {}
+  '@platforma-open/milaboratories.software-ptexter@1.2.4': {}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10': {}
 
@@ -8661,42 +8594,19 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.11.6(@types/node@25.0.3)':
-    dependencies:
-      '@aws-sdk/client-s3': 3.859.0
-      '@inquirer/prompts': 7.10.1(@types/node@25.0.3)
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.9
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.3
-      '@platforma-sdk/blocks-deps-updater': 2.2.0
-      canonicalize: 2.1.0
-      commander: 15.0.0
-      lru-cache: 11.2.4
-      mime-types: 2.1.35
-      tar: 7.5.2
-      undici: 7.16.0
-      yaml: 2.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@types/node'
-      - aws-crt
-
-  '@platforma-sdk/block-tools@2.12.0(@types/node@25.0.3)':
+  '@platforma-sdk/block-tools@2.12.9(@types/node@25.0.3)':
     dependencies:
       '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0
       '@inquirer/prompts': 7.10.1(@types/node@25.0.3)
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.13
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/pl-model-backend': 1.4.18
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/pl-model-middle-layer': 1.30.15
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.6
       '@platforma-sdk/blocks-deps-updater': 2.2.0
-      '@platforma-sdk/package-builder-lib': 1.2.0
+      '@platforma-sdk/package-builder-lib': 1.2.1
       canonicalize: 2.1.0
       commander: 15.0.0
       lru-cache: 11.2.4
@@ -8715,20 +8625,21 @@ snapshots:
     dependencies:
       yaml: 2.8.2
 
-  '@platforma-sdk/model@1.79.20':
+  '@platforma-sdk/model@1.80.10':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.5
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/ptabler-expression-js': 1.2.31
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/pl-model-middle-layer': 1.30.15
+      '@milaboratories/ptabler-expression-js': 1.2.37
       canonicalize: 2.1.0
       es-toolkit: 1.43.0
       fast-json-patch: 3.1.1
+      lru-cache: 11.2.4
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@platforma-sdk/package-builder-lib@1.1.0':
+  '@platforma-sdk/package-builder-lib@1.2.1':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
@@ -8743,24 +8654,9 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@platforma-sdk/package-builder-lib@1.2.0':
+  '@platforma-sdk/package-builder@3.14.2':
     dependencies:
-      '@aws-sdk/client-s3': 3.859.0
-      '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
-      '@milaboratories/resolve-helper': 1.1.3
-      archiver: 7.0.1
-      undici: 7.16.0
-      winston: 3.19.0
-      yaml: 2.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - aws-crt
-      - bare-abort-controller
-      - react-native-b4a
-
-  '@platforma-sdk/package-builder@3.14.0':
-    dependencies:
-      '@platforma-sdk/package-builder-lib': 1.1.0
+      '@platforma-sdk/package-builder-lib': 1.2.1
       commander: 15.0.0
       winston: 3.19.0
     transitivePeerDependencies:
@@ -8768,22 +8664,22 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@platforma-sdk/tengo-builder@4.0.11':
+  '@platforma-sdk/tengo-builder@4.0.20':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.4.9
+      '@milaboratories/pl-model-backend': 1.4.18
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.6
       commander: 15.0.0
       winston: 3.19.0
 
-  '@platforma-sdk/test@1.79.23(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.80.11(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))':
     dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-middle-layer': 1.64.41(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)
-      '@milaboratories/pl-tree': 1.12.14
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/computable': 2.9.8
+      '@milaboratories/pl-client': 3.14.4
+      '@milaboratories/pl-middle-layer': 1.66.10(@bytecodealliance/preview2-shim@0.17.8)(@types/node@25.0.3)
+      '@milaboratories/pl-tree': 1.13.3
+      '@platforma-sdk/model': 1.80.10
       '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
       vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -8807,12 +8703,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.80.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.4.16(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/uikit': 2.15.11(typescript@5.9.3)
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/columns-collection-driver': 0.2.3
+      '@milaboratories/pf-spec-driver': 1.4.24(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/uikit': 2.15.18(typescript@5.9.3)
+      '@platforma-sdk/model': 1.80.10
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -8843,20 +8740,12 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@6.6.5':
+  '@platforma-sdk/workflow-tengo@6.8.2':
     dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.52
+      '@milaboratories/pframes-rs-wasip2': 1.1.56
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.3
-      '@platforma-open/milaboratories.software-ptexter': 1.2.2
-      '@platforma-open/milaboratories.software-small-binaries': 2.1.1
-
-  '@platforma-sdk/workflow-tengo@6.7.0':
-    dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.52
-      '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.4
-      '@platforma-open/milaboratories.software-ptexter': 1.2.3
+      '@platforma-open/milaboratories.software-ptabler': 2.1.8
+      '@platforma-open/milaboratories.software-ptexter': 1.2.4
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
@@ -8983,7 +8872,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.1
       '@emnapi/runtime': 1.9.1
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.5':
@@ -11563,11 +11452,6 @@ snapshots:
       '@stdlib/utils-constructor-name': 0.2.2
       '@stdlib/utils-global': 0.2.2
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -11674,7 +11558,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
-      obug: 2.1.1
+      obug: 2.1.3
       tinyrainbow: 3.1.0
       vitest: 4.1.3(@types/node@25.0.3)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@25.0.3)(esbuild@0.27.2)(yaml@2.8.2))
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,31 +8,31 @@ packages:
 
 catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
-  '@milaboratories/ts-builder': 1.6.0
-  '@milaboratories/ts-configs': 1.3.0
-  '@platforma-sdk/workflow-tengo': 6.7.0
-  '@platforma-sdk/model': 1.79.20
-  '@platforma-sdk/ui-vue': 1.79.20
-  '@platforma-sdk/tengo-builder': 4.0.11
-  '@platforma-sdk/package-builder': 3.14.0
-  '@platforma-sdk/block-tools': 2.12.0
-  '@platforma-sdk/test': 1.79.23
-  '@milaboratories/helpers': 1.14.2
-  '@milaboratories/graph-maker': 1.4.6
-  '@milaboratories/multi-sequence-alignment': 1.47.16
-  '@milaboratories/strings': 0.1.2
+  "@milaboratories/ts-builder": 1.6.1
+  "@milaboratories/ts-configs": 1.3.1
+  "@platforma-sdk/workflow-tengo": 6.8.2
+  "@platforma-sdk/model": 1.80.10
+  "@platforma-sdk/ui-vue": 1.80.10
+  "@platforma-sdk/tengo-builder": 4.0.20
+  "@platforma-sdk/package-builder": 3.14.2
+  "@platforma-sdk/block-tools": 2.12.9
+  "@platforma-sdk/test": 1.80.11
+  "@milaboratories/helpers": 1.14.5
+  "@milaboratories/graph-maker": 1.4.6
+  "@milaboratories/multi-sequence-alignment": 1.47.16
+  "@milaboratories/strings": 0.1.2
 
-  '@milaboratories/software-pframes-conv': 2.2.9
-  '@platforma-open/milaboratories.runenv-python-3': 1.7.9
+  "@milaboratories/software-pframes-conv": 2.2.9
+  "@platforma-open/milaboratories.runenv-python-3": 1.11.5
 
   # Common dependencies - can use ^ or ~
-  '@vueuse/core': ^13.3.0
-  '@types/node': ^24.5.2
-  'vue': 3.5.24
-  'typescript': ~5.6.3
-  'turbo': ^2.6.3
-  'vitest': ^4.0.18
-  'eslint': ^9.25.1
-  '@changesets/cli': ^2.29.8
-  'js-yaml': ^4.1.0
-  'shx': ^0.4.0
+  "@vueuse/core": ^13.3.0
+  "@types/node": ^24.5.2
+  "vue": 3.5.24
+  "typescript": ~5.6.3
+  "turbo": ^2.6.3
+  "vitest": ^4.0.18
+  "eslint": ^9.25.1
+  "@changesets/cli": ^2.29.8
+  "js-yaml": ^4.1.0
+  "shx": ^0.4.0

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -745,6 +745,11 @@ def parse_args():
                         help='Embedding-dimension column name in the embedding matrix (default: embeddingDim).')
     parser.add_argument('--value-col', default='value',
                         help='Embedding-value column name in the embedding matrix (default: value).')
+    parser.add_argument('--dims', default=None,
+                        help='Embedding vector length D (--encoding embedding), from the input column\'s '
+                             'pl7.app/embedding/length annotation. Lets the streaming loader resolve D '
+                             'without a scan; when omitted D is inferred as max(embeddingDim)+1 in the '
+                             'first row group.')
     parser.add_argument('--embedding-model', default=None,
                         help='Embedding model identifier, logged to the processing log for provenance '
                              '(--encoding embedding). Stamped on the output column domain by the workflow.')
@@ -1046,56 +1051,98 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
 # ============================================================================
 #
 # UMAP on learned per-clonotype embedding vectors. Order is load-bearing:
-#   load matrix → vector-dedup → centered PCA-95% → L2-normalize → Euclidean UMAP.
+#   centered PCA-95% → L2-normalize → Euclidean UMAP.
 # Centered PCA removes ESM-2's large non-discriminative shared mean, so the post-PCA
 # L2-normalize + Euclidean (≡ cosine ranking) then measures the mean-removed residuals.
-# Reuses create_umap_model (CPU/GPU backends) but NOT run_cpu/gpu_pipeline — the matrix is already
-# materialized, so there is no per-chunk feature recompute.
+#
+# Memory handling for large inputs: the full N x D matrix is NEVER materialized. The CPU path
+# STREAMS the long-format parquet twice — once to collect a bounded, seeded fit sample
+# (~max_sequences x D), once to project every clonotype through the fitted PCA/UMAP in batches — so
+# peak memory is bounded by the fit sample, independent of N. The GPU path (G2) streams the load
+# straight into a device array (host stays bounded) and keeps cuML's fit-on-all behaviour unchanged.
+# Exact-duplicate vectors are NOT de-duplicated before the fit to avoid memory scaling.
 
-def load_embedding_matrix(path, key_col, dim_col, value_col):
-    """Read the long-format embedding matrix (parquet) → (X float32, keys object array).
+# Fixed, data-derived batch size for the streaming reads: 4M long-format rows per pyarrow batch.
+# Deliberately NOT scaled by the allocated memory — a fixed batch keeps assembly deterministic and the
+# per-batch footprint constant regardless of the RAM the backend granted.
+EMBEDDING_STREAM_BATCH_ROWS = 4_000_000
 
-    The parquet has one row per (clonotype, embeddingDim). Rather than sorting the whole N*D-row frame
-    (a full sorted copy — the dominant memory cost at scale), the matrix is built by SCATTER: factorize
-    the clonotype key to an integer code, then place each value at X[code, dim]. This is order-
-    independent (dim positions the column, code positions the row) and avoids the sort entirely. Casting
-    the key to Categorical keeps only the unique keys + per-row codes instead of N*D expanded strings.
 
-    Keys come back in physical-code (first-appearance) order; row order does not matter downstream
-    (dedup re-sorts; the output pframe is keyed by clonotype value, not row position). Kept float32.
+class _EmptyEmbeddingResult(Exception):
+    """Signals that an embedding path already wrote the empty output files and processing should
+    unwind to the caller (empty / too-few-vector inputs)."""
 
-    Completeness (the ragged-matrix check, R-equivalent): a full, duplicate-free fill requires BOTH
-    `len(vals) == n*D` (no extra/duplicate rows) AND no unfilled cell after the scatter (no missing dim).
-    embeddingDim is the producer's 0..D-1 index, used directly as the column index; D is inferred as
-    max(dim)+1."""
-    df = pl.read_parquet(path, columns=[key_col, dim_col, value_col])
-    if df.height == 0:
-        return np.empty((0, 0), dtype=np.float32), np.array([], dtype=object)
 
-    cat = df.get_column(key_col).cast(pl.Categorical)
-    keys = cat.cat.get_categories()                 # unique clonotype keys, in physical-code order
-    n = keys.len()
-    codes = cat.to_physical().to_numpy()            # per-row clonotype index 0..n-1 (aligns with `keys`)
-    dims = df.get_column(dim_col).to_numpy()         # per-row embeddingDim index
-    vals = df.get_column(value_col).cast(pl.Float32).to_numpy()
-    del df, cat
+def _open_matrix(path, key_col, dim_col, value_col, dims):
+    """Open the long-format parquet and resolve D without scanning the file. Validates the three
+    columns exist; D comes from --dims (the pl7.app/embedding/length annotation) when given, else
+    max(embeddingDim)+1 in the first row group. Returns (ParquetFile, D)."""
+    import pyarrow.parquet as pq
+    pf = pq.ParquetFile(path)
+    names = list(pf.schema_arrow.names)
+    for role, col in [("--key-col", key_col), ("--dim-col", dim_col), ("--value-col", value_col)]:
+        if col not in names:
+            raise ValueError(f"{role} {col!r} is not a column in {path}; available columns: {names}")
+    if pf.metadata.num_rows == 0:            # empty input -> D irrelevant (caller writes empty output)
+        return pf, int(dims) if dims else 0
+    if dims:
+        return pf, int(dims)
+    D = int(pl.from_arrow(pf.read_row_group(0, columns=[dim_col])).get_column(dim_col).max()) + 1
+    return pf, D
 
-    if dims.min() < 0:
-        raise ValueError(f"embeddingDim must be a 0-based index; got a negative value {int(dims.min())}.")
-    D = int(dims.max()) + 1
 
-    if vals.shape[0] != n * D:
-        raise ValueError(
-            f"Ragged embedding matrix: {vals.shape[0]} rows != n*D ({n}*{D}) — a clonotype has extra "
-            f"or duplicate (clonotype, dim) rows.")
+def _clonotype_count(pf, D):
+    """Clonotype count = long rows / D, taken from the parquet footer (no scan)."""
+    return 0 if D <= 0 else pf.metadata.num_rows // D
 
-    X = np.full((n, D), np.nan, dtype=np.float32)
-    X[codes, dims] = vals                            # scatter: row = clonotype, col = embeddingDim
-    if np.isnan(X).any():
-        raise ValueError(
-            "Ragged embedding matrix: a (clonotype, dim) cell is missing — a clonotype has a partial "
-            "embedding-dimension set.")
-    return X, keys.to_numpy().astype(object)
+
+def _stream_clonotypes(pf, key_col, dim_col, value_col, D, batch_rows=EMBEDDING_STREAM_BATCH_ROWS):
+    """Yield (keys, matrix) blocks of whole clonotypes, assembled from contiguous long-format rows and
+    holding back the trailing clonotype that may continue in the next batch. Memory bounded to ~one
+    batch. Copied from embedding-clustering; keep the guards in sync."""
+    def build(ks, ds, vs):
+        # np.unique -> distinct keys `uk` (sorted) + `inv` (per-row index into uk). Scattering
+        # mat[inv, ds] = vs drops each value into its (clonotype, embeddingDim) cell, so row order
+        # within the block does not matter.
+        uk, inv = np.unique(ks, return_inverse=True)
+        # Row-count guard: each clonotype must have exactly D contiguous rows.
+        if (np.bincount(inv) != D).any():
+            raise ValueError("a clonotype did not have exactly D contiguous rows -- the embedding "
+                             "matrix is not clonotype-blocked (the streaming loader needs contiguous rows).")
+        # Dimension-range guard: embeddingDim must be a 0..D-1 index.
+        if ds.min() < 0 or ds.max() >= D:
+            raise ValueError(f"embeddingDim out of range [0, {D}); saw {int(ds.min())}..{int(ds.max())} "
+                             f"-- pass the correct --dims (the pl7.app/embedding/length annotation).")
+        # Completeness: NaN-fill, scatter, require no cell left unset -- catches a duplicated dim (hence
+        # a missing dim -> an unfilled hole) and any NaN in the value column.
+        mat = np.full((uk.shape[0], D), np.nan, dtype=np.float32)
+        mat[inv, ds] = vs
+        if np.isnan(mat).any():
+            raise ValueError("ragged embedding matrix: a (clonotype, dim) cell is missing, duplicated, "
+                             "or NaN -- a clonotype has a partial/invalid embedding-dimension set.")
+        return uk, mat
+
+    leftover = None
+    for b in pf.iter_batches(columns=[key_col, dim_col, value_col], batch_size=batch_rows):
+        t = pl.from_arrow(b)
+        k = t.get_column(key_col).to_numpy().astype(object)
+        d = t.get_column(dim_col).to_numpy()
+        v = t.get_column(value_col).cast(pl.Float32).to_numpy()
+        # A clonotype's D rows can straddle a batch boundary, so prepend the previous batch's
+        # carried-over trailing clonotype before assembling this batch.
+        if leftover is not None:
+            k = np.concatenate([leftover[0], k])
+            d = np.concatenate([leftover[1], d])
+            v = np.concatenate([leftover[2], v])
+        # Hold back the LAST key's rows (they may continue in the next batch); assemble + emit the rest.
+        tail = k == k[-1]
+        leftover = (k[tail], d[tail], v[tail])
+        keep = ~tail
+        if keep.any():
+            yield build(k[keep], d[keep], v[keep])
+    # The final trailing clonotype has no continuation -- emit it.
+    if leftover is not None:
+        yield build(*leftover)
 
 
 def l2_normalize(X, eps=1e-12):
@@ -1115,118 +1162,183 @@ def _select_k_for_variance(explained_variance_ratio, target=SVD_TARGET_VARIANCE)
     return len(explained_variance_ratio)
 
 
-def _pca_reduce_sklearn(X_fit, X_all, ncomp):
-    """Centered PCA on CPU (sklearn, svd_solver='full', deterministic). Fit on X_fit, transform X_all,
-    slice to the 95%-variance k. Returns (Xr float32, k)."""
+def _fit_pca_cpu(X_fit):
+    """Centered PCA (sklearn, svd_solver='full', deterministic) fit on the fit sample. Returns
+    (pca, k) with k the 95%-variance component count (cap SVD_MAX_COMPONENTS); any batch is projected
+    as pca.transform(batch)[:, :k]. Returns (None, D) for a sample too small to fit (guarded upstream —
+    the caller writes an empty output before this is reached in practice)."""
     from sklearn.decomposition import PCA
-    print("Using CPU-based centered PCA (scikit-learn, svd_solver='full')...")
+    n_fit, D = X_fit.shape
+    ncomp = min(SVD_MAX_COMPONENTS, n_fit - 1, D)
+    if ncomp < 1:
+        return None, D
+    print("Fitting centered PCA (scikit-learn, svd_solver='full') on the fit sample...")
     pca = PCA(n_components=ncomp, svd_solver='full').fit(X_fit)  # centered by default
     k = min(_select_k_for_variance(pca.explained_variance_ratio_), ncomp)
-    Xr = pca.transform(X_all)[:, :k].astype(np.float32)
-    _mark_exec('svd', 'CPU', 'sklearn PCA-95% (embedding mode)')
-    return Xr, k
+    _mark_exec('svd', 'CPU', 'sklearn PCA-95% (embedding mode, streamed)')
+    return pca, k
 
 
-def _pca_reduce_cuml(X_fit, X_all, ncomp):
-    """Centered PCA on GPU (cuML, svd_solver='full'). Net-new vs the k-mer path's sparse SVD; wrapped by
-    an OOM/error guard + CPU fallback in embedding_pca_reduce. Returns (Xr float32, k)."""
-    import cuml  # noqa: F401
-    from cuml.decomposition import PCA as cuPCA
-    print("Using GPU-accelerated centered PCA (RAPIDS cuML, svd_solver='full')...")
-    pca = cuPCA(n_components=ncomp, svd_solver='full').fit(X_fit)
-    evr = pca.explained_variance_ratio_
-    try:
-        import cupy as cp
-        evr = cp.asnumpy(evr)
-        k = min(_select_k_for_variance(np.asarray(evr)), ncomp)
-        Xr = cp.asnumpy(pca.transform(X_all))
-    except ImportError:
-        evr = np.asarray(evr)
-        k = min(_select_k_for_variance(evr), ncomp)
-        Xr = np.asarray(pca.transform(X_all))
-    _mark_exec('svd', 'GPU', 'cuML PCA-95% (embedding mode)')
-    return Xr[:, :k].astype(np.float32), k
-
-
-def _fit_sample(X, max_sequences, n):
-    """Seeded fit-sample for the CPU PCA fit (the dense svd_solver='full' fit on all rows is a CPU
-    bottleneck). Returns X unchanged when max_sequences is 0/disabled or n is already below it."""
-    if max_sequences and max_sequences > 0 and n > max_sequences:
-        rng = np.random.default_rng(RANDOM_STATE)
-        print(f"PCA fit-sample (CPU): {n} unique vectors > --max-sequences={max_sequences}; "
-              f"fitting on {max_sequences} sampled vectors, transforming all.")
-        return X[rng.choice(n, size=max_sequences, replace=False)]
-    return X
-
-
-def embedding_pca_reduce(X, args):
-    """Centered PCA → the 95%-variance component count (cap SVD_MAX_COMPONENTS); transform ALL rows.
-
-    Per-backend fit policy mirrors the sequence path exactly:
-      - GPU (cuML): fit on ALL unique rows, no cap — like run_gpu_pipeline (sequence GPU fits on all).
-      - CPU (sklearn): fit on a seeded --max-sequences sample — like run_cpu_pipeline, since dense
-        svd_solver='full' on all rows is a CPU bottleneck.
-    A GPU OOM/error falls back to the (fit-sampled).
-    Returns (Xr float32, k)."""
-    n, D = X.shape
-    cap = min(SVD_MAX_COMPONENTS, n - 1, D)
-    if cap < 1:
-        return X.astype(np.float32), D
-
-    if args.svd_backend in ('cuml', 'auto'):
-        try:
-            ncomp = min(cap, n - 1, D)   # GPU: fit on ALL unique rows (no cap)
-            return _pca_reduce_cuml(X, X, ncomp)
-        except Exception as e:  # noqa: BLE001 — OOM/import/CUDA all fall back to CPU
-            if args.svd_backend == 'cuml':
-                print(f"Error: cuML PCA failed and backend forced to 'cuml': {e}")
-                raise
-            print(f"cuML PCA unavailable or failed ({e}); falling back to CPU PCA (fit-sampled).")
-
-    # CPU: fit on a seeded --max-sequences sample (matches the sequence CPU path), transform all.
-    X_fit = _fit_sample(X, args.max_sequences, n)
-    ncomp = min(cap, X_fit.shape[0] - 1, D)
-    return _pca_reduce_sklearn(X_fit, X, ncomp)
-
-
-def run_embedding_umap(Xn, umap_model, run_type, args):
-    """Fit/transform UMAP on the reduced, L2-normalized matrix (already materialized — no per-chunk
-    feature recompute). GPU: single fit_transform on all rows. CPU: fit on a sub-sample
-    (UMAP_FIT_MAX_SAMPLE_SIZE), transform all rows. Default metric is Euclidean on both backends, which
-    on L2-normalized vectors is a monotonic function of cosine similarity. Returns (n, 2) coords."""
-    n = Xn.shape[0]
-    start = time.time()
-    fell_back = False
-    if run_type == 'gpu':
-        try:
-            coords = np.asarray(umap_model.fit_transform(Xn))
-            _mark_exec('umap', 'GPU', 'cuML UMAP.fit_transform() returned (embedding mode)')
-            print(f"UMAP (GPU) completed in {time.time() - start:.2f} seconds.\n")
-            return coords
-        except Exception as e:  # noqa: BLE001
-            print(f"Warning: GPU UMAP failed - {e}. Falling back to CPU UMAP...")
-            umap_model, run_type = create_umap_model(
-                'sklearn', args.umap_components, args.umap_neighbors, args.umap_min_dist)
-            fell_back = True
-
-    # Isolated, seeded RNG (deterministic, doesn't touch global numpy state) — matches _fit_sample.
+def _fit_umap_cpu(umap_model, Xn_fit):
+    """Fit umap-learn on the L2-normalized fit-sample reduction. Sub-samples to
+    UMAP_FIT_MAX_SAMPLE_SIZE first (seeded, isolated RNG), matching the pre-streaming CPU UMAP fit
+    size. Xn_fit is already L2-normalized (Euclidean ≡ cosine ranking)."""
+    n = Xn_fit.shape[0]
     rng = np.random.default_rng(RANDOM_STATE)
     if n > UMAP_FIT_MAX_SAMPLE_SIZE:
-        print(f"Fit sample ({n}) > {UMAP_FIT_MAX_SAMPLE_SIZE}. "
-              f"Sampling {UMAP_FIT_MAX_SAMPLE_SIZE} vectors for UMAP fitting.")
+        print(f"UMAP fit sample ({n}) > {UMAP_FIT_MAX_SAMPLE_SIZE}. "
+              f"Sub-sampling {UMAP_FIT_MAX_SAMPLE_SIZE} vectors for the UMAP fit.")
         idx = rng.choice(n, size=UMAP_FIT_MAX_SAMPLE_SIZE, replace=False)
-        umap_model.fit(Xn[idx])
+        umap_model.fit(Xn_fit[idx])
     else:
-        umap_model.fit(Xn)
-    coords = np.asarray(umap_model.transform(Xn))
-    detail = (
-        'umap-learn fit+transform (embedding mode, fallback after GPU UMAP failure)'
-        if fell_back
-        else 'umap-learn fit+transform (embedding mode)'
-    )
-    _mark_exec('umap', 'CPU', detail)
-    print(f"UMAP (CPU) completed in {time.time() - start:.2f} seconds.\n")
-    return coords
+        umap_model.fit(Xn_fit)
+    _mark_exec('umap', 'CPU', 'umap-learn UMAP.fit() returned (embedding mode, streamed)')
+
+
+def _transform_batch_cpu(pca, k, umap_model, n_components, X_batch):
+    """Project one clonotype block through the fitted PCA + UMAP (out-of-sample transform). Degenerate
+    (near-zero post-PCA residual) rows get NaN coords (null downstream), matching the fit-side
+    exclusion. Returns (coords float64 (b, n_components), n_degenerate)."""
+    reduced = X_batch if pca is None else pca.transform(X_batch)[:, :k]
+    coords = np.full((reduced.shape[0], n_components), np.nan, dtype=np.float64)
+    valid = np.linalg.norm(reduced, axis=1) > DEGENERATE_NORM_THRESHOLD
+    if valid.any():
+        coords[valid] = np.asarray(umap_model.transform(l2_normalize(reduced[valid])))
+    return coords, int((~valid).sum())
+
+
+def _run_embedding_cpu(pf, D, n_clonotypes, min_required, args, output_path):
+    """CPU two-pass streaming path. Pass A: stream once, gather a seeded fit sample bounded to
+    ~max_sequences x D. Fit PCA + UMAP on it. Pass B: stream again, project every clonotype through the
+    fitted models in batches, accumulating only the 2-D coordinates. Never holds the full N x D matrix.
+    Returns (keys, coords, n_degenerate, k_pca); raises _EmptyEmbeddingResult when there are too few
+    non-degenerate vectors (empty output already written)."""
+    fit_size = args.max_sequences if (args.max_sequences and args.max_sequences > 0) else n_clonotypes
+    fit_size = min(fit_size, n_clonotypes)
+
+    # --- Pass A: gather the seeded fit sample. choice-over-N is the same sampling algorithm as the
+    #     pre-streaming _fit_sample; collected in stream order via a global row counter. ---
+    rng = np.random.default_rng(RANDOM_STATE)
+    if fit_size < n_clonotypes:
+        sel = np.sort(rng.choice(n_clonotypes, size=fit_size, replace=False))
+        print(f"Fit sample: {n_clonotypes} clonotypes > --max-sequences={args.max_sequences}; "
+              f"gathering {fit_size} sampled vectors while streaming (PCA/UMAP fit on the sample, all "
+              f"clonotypes transformed).")
+    else:
+        sel = np.arange(n_clonotypes)
+        print(f"Fit sample: {n_clonotypes} clonotypes <= --max-sequences; fitting on all.")
+
+    X_fit = np.empty((fit_size, D), dtype=np.float32)
+    g = 0
+    for _, mat in _stream_clonotypes(pf, args.key_col, args.dim_col, args.value_col, D):
+        b = mat.shape[0]
+        lo = int(np.searchsorted(sel, g))
+        hi = int(np.searchsorted(sel, g + b))
+        if hi > lo:
+            X_fit[lo:hi] = mat[sel[lo:hi] - g]
+        g += b
+    print(f"Fit sample gathered: {X_fit.shape[0]} x {D} (peak RSS {_peak_rss_gib():.2f} GiB).")
+
+    # --- Fit centered PCA on the sample ---
+    start_pca = time.time()
+    pca, k_pca = _fit_pca_cpu(X_fit)
+    Xr_fit = X_fit if pca is None else pca.transform(X_fit)[:, :k_pca]
+    print(f"Centered PCA: {D} → {k_pca} components (95% variance, cap {SVD_MAX_COMPONENTS}) "
+          f"in {time.time() - start_pca:.2f}s.")
+
+    # --- Degenerate check on the fit sample; fit UMAP on its non-degenerate rows ---
+    valid_fit = np.linalg.norm(Xr_fit, axis=1) > DEGENERATE_NORM_THRESHOLD
+    n_valid_fit = int(valid_fit.sum())
+    if n_valid_fit < min_required:
+        print(f"Warning: Not enough non-degenerate vectors in the fit sample for UMAP "
+              f"(required {min_required}, valid {n_valid_fit}) — writing empty output.")
+        create_empty_umap_output(KEY_COL, args.umap_components, output_path)
+        create_empty_skipped_summary(args.output_dir,
+                                     "UMAP analysis skipped due to insufficient non-degenerate vectors.")
+        raise _EmptyEmbeddingResult()
+
+    umap_model, _ = create_umap_model('sklearn', args.umap_components, args.umap_neighbors,
+                                      args.umap_min_dist)
+    print(f"Fitting UMAP on {n_valid_fit} non-degenerate fit-sample vectors "
+          f"(L2-normalized, Euclidean ≡ cosine)...")
+    start_umap = time.time()
+    _fit_umap_cpu(umap_model, l2_normalize(Xr_fit[valid_fit]))
+    print(f"UMAP fit completed in {time.time() - start_umap:.2f}s.")
+
+    # --- Pass B: project every clonotype in batches (out-of-sample transform) ---
+    start_tr = time.time()
+    keys_parts, coords_parts, n_degenerate = [], [], 0
+    for ks, mat in _stream_clonotypes(pf, args.key_col, args.dim_col, args.value_col, D):
+        c, nd = _transform_batch_cpu(pca, k_pca, umap_model, args.umap_components, mat)
+        keys_parts.append(ks)
+        coords_parts.append(c)
+        n_degenerate += nd
+    keys = np.concatenate(keys_parts) if keys_parts else np.array([], dtype=object)
+    coords = np.vstack(coords_parts) if coords_parts else np.empty((0, args.umap_components))
+    print(f"Transformed all {keys.shape[0]} clonotypes in {time.time() - start_tr:.2f}s "
+          f"(degenerate-excluded={n_degenerate}).")
+    return keys, coords, n_degenerate, k_pca
+
+
+def _run_embedding_gpu(pf, D, n_clonotypes, min_required, args, output_path):
+    """GPU path: stream the long-format parquet straight into a preallocated device array (the
+    host never holds more than one batch — the eager host-RAM peak is gone), then keep cuML's
+    fit-on-all behaviour unchanged: cuPCA fit+transform on ALL clonotypes, cuML UMAP fit_transform on
+    all. Returns (keys, coords, n_degenerate, k_pca). Raises _EmptyEmbeddingResult for too-few valid
+    vectors; raises on any GPU/CUDA error so the caller can fall back to the CPU streaming path."""
+    import cupy as cp
+    import cuml  # noqa: F401
+    from cuml.decomposition import PCA as cuPCA
+
+    Xd = cp.empty((n_clonotypes, D), dtype=cp.float32)
+    keys = np.empty(n_clonotypes, dtype=object)
+    g = 0
+    for ks, mat in _stream_clonotypes(pf, args.key_col, args.dim_col, args.value_col, D):
+        b = mat.shape[0]
+        Xd[g:g + b] = cp.asarray(mat)
+        keys[g:g + b] = ks
+        g += b
+    print(f"Streamed {g} clonotypes into VRAM ({Xd.nbytes / 1024**3:.2f} GiB on device; "
+          f"host peak RSS {_peak_rss_gib():.2f} GiB).")
+
+    # Centered PCA on ALL clonotypes (device) — unchanged fit-on-all behaviour.
+    ncomp = min(SVD_MAX_COMPONENTS, n_clonotypes - 1, D)
+    print("Fitting centered PCA (RAPIDS cuML, svd_solver='full') on ALL clonotypes (GPU)...")
+    pca = cuPCA(n_components=ncomp, svd_solver='full').fit(Xd)
+    k_pca = min(_select_k_for_variance(cp.asnumpy(pca.explained_variance_ratio_)), ncomp)
+    Xr = pca.transform(Xd)[:, :k_pca]
+    _mark_exec('svd', 'GPU', 'cuML PCA-95% (embedding mode, streamed load)')
+    print(f"Centered PCA: {D} → {k_pca} components (95% variance, cap {SVD_MAX_COMPONENTS}).")
+
+    # Degenerate detection + eps-guarded L2-normalize on device (mirrors l2_normalize).
+    pre_norm = cp.linalg.norm(Xr, axis=1)
+    valid = pre_norm > DEGENERATE_NORM_THRESHOLD
+    n_valid = int(valid.sum())
+    n_degenerate = int(n_clonotypes - n_valid)
+    if n_degenerate:
+        print(f"Warning: {n_degenerate} vector(s) near-zero norm post-PCA — excluded, null coords.")
+    if n_valid < min_required:
+        print(f"Warning: Not enough non-degenerate vectors for UMAP "
+              f"(required {min_required}, valid {n_valid}) — writing empty output.")
+        create_empty_umap_output(KEY_COL, args.umap_components, output_path)
+        create_empty_skipped_summary(args.output_dir,
+                                     "UMAP analysis skipped due to insufficient non-degenerate vectors.")
+        raise _EmptyEmbeddingResult()
+    Xn = Xr[valid] / cp.maximum(pre_norm[valid][:, None], 1e-12)
+
+    umap_model, run_type = create_umap_model(args.umap_backend, args.umap_components,
+                                             args.umap_neighbors, args.umap_min_dist)
+    if run_type != 'gpu':
+        raise RuntimeError("cuML UMAP unavailable despite a usable GPU PCA — deferring to CPU path.")
+    print(f"Running UMAP (GPU, fit_transform on all {n_valid} non-degenerate vectors)...")
+    start_umap = time.time()
+    coords_valid = cp.asnumpy(umap_model.fit_transform(Xn))
+    _mark_exec('umap', 'GPU', 'cuML UMAP.fit_transform() returned (embedding mode, streamed load)')
+    print(f"UMAP (GPU) completed in {time.time() - start_umap:.2f}s.")
+
+    coords = np.full((n_clonotypes, args.umap_components), np.nan, dtype=np.float64)
+    coords[cp.asnumpy(valid)] = coords_valid
+    return keys, coords, n_degenerate, k_pca
 
 
 def _peak_rss_gib():
@@ -1239,19 +1351,16 @@ def _peak_rss_gib():
 
 
 def run_embedding_mode(args, output_path):
-    """Embedding feature path: load matrix → vector-dedup → centered PCA-95% → L2-normalize (eps-guarded,
-    degenerate rows excluded) → Euclidean UMAP → broadcast back to all clonotypes → write outputs.
-
-    Empty / too-few-rows inputs write an empty output and return (the k-mer path's guards are TSV/
-    sequence-specific, so embedding mode carries its own here). Clonotypes ABSENT from the embedding
-    column never enter this input, so they are simply absent from the output (sparse), like the k-mer
-    path's no-sequence drop — not the invalid-character null-coord path."""
-    print(f"Loading embedding matrix {args.matrix} ...")
-    X, keys = load_embedding_matrix(args.matrix, args.key_col, args.dim_col, args.value_col)
-    n_clonotypes = X.shape[0]
-    D = X.shape[1] if n_clonotypes else 0
-    print(f"Loaded {n_clonotypes} clonotypes x {D} embedding dims.")
-    print(f"Peak memory after matrix load: {_peak_rss_gib():.2f} GiB")
+    """Embedding feature path: stream matrix → centered PCA-95% → L2-normalize (degenerate rows
+    excluded, null coords) → Euclidean UMAP → write outputs. The full N x D matrix is never
+    materialized (see the module comment above). Empty / too-few-clonotype inputs write an empty
+    output. Clonotypes ABSENT from the embedding column never enter this input, so they are simply
+    absent from the output (sparse) — not the invalid-character null-coord path."""
+    print(f"Opening embedding matrix {args.matrix} ...")
+    pf, D = _open_matrix(args.matrix, args.key_col, args.dim_col, args.value_col, args.dims)
+    n_clonotypes = _clonotype_count(pf, D)
+    print(f"Embedding matrix: {n_clonotypes} clonotypes x {D} embedding dims "
+          f"(from parquet footer; no full load).")
 
     if n_clonotypes == 0:
         print("Warning: Embedding matrix is empty — writing empty output.")
@@ -1261,81 +1370,51 @@ def run_embedding_mode(args, output_path):
         return
 
     min_required = max(args.umap_neighbors + 1, 4)
-
-    # Vector-dedup (exact, bit-identical for same-model embeddings): collapse identical rows before the
-    # fit, re-expand after via the inverse index.
-    uniq, inv = np.unique(X, axis=0, return_inverse=True)
-    inv = inv.ravel()
-    n_unique = uniq.shape[0]
-    if n_unique < n_clonotypes:
-        print(f"Deduplicating vectors: {n_clonotypes} → {n_unique} unique "
-              f"({n_clonotypes - n_unique} identical vectors collapsed for PCA/UMAP).")
-
-    if n_unique < min_required:
-        print(f"Warning: Not enough unique embedding vectors for UMAP "
-              f"(required {min_required}, unique {n_unique}) — writing empty output.")
+    if n_clonotypes < min_required:
+        print(f"Warning: Not enough clonotypes for UMAP (required {min_required}, "
+              f"have {n_clonotypes}) — writing empty output.")
         create_empty_umap_output(KEY_COL, args.umap_components, output_path)
         create_empty_skipped_summary(args.output_dir,
-                                     "UMAP analysis skipped due to insufficient unique vectors.")
+                                     "UMAP analysis skipped due to insufficient clonotypes.")
         return
 
-    # Centered PCA → 95% variance (cap 500). GPU fits on all unique rows (no cap, like the sequence
-    # GPU path); CPU fits on a seeded --max-sequences sample.
-    start_pca = time.time()
-    Xr, k_pca = embedding_pca_reduce(uniq, args)
-    print(f"Centered PCA: {uniq.shape[1]} → {k_pca} components (95% variance, cap "
-          f"{SVD_MAX_COMPONENTS}) in {time.time() - start_pca:.2f}s.")
+    # Backend: try the GPU path unless a backend is pinned to sklearn; fall back to CPU streaming
+    # on any GPU/CUDA failure. Neither path holds the full N x D matrix in host RAM.
+    try_gpu = args.umap_backend in ('cuml', 'auto') and args.svd_backend != 'sklearn'
+    used_gpu = False
+    result = None
+    if try_gpu:
+        try:
+            result = _run_embedding_gpu(pf, D, n_clonotypes, min_required, args, output_path)
+            used_gpu = True
+        except _EmptyEmbeddingResult:
+            return
+        except Exception as e:  # noqa: BLE001 — OOM/import/CUDA all fall back to CPU streaming
+            if args.umap_backend == 'cuml':
+                print(f"Error: GPU embedding path failed and --umap-backend forced to 'cuml': {e}")
+                raise
+            print(f"GPU embedding path unavailable or failed ({e}); falling back to CPU streaming.")
 
-    # Degenerate (near-zero post-PCA residual) detection BEFORE normalization: such a vector sits at the
-    # dataset mean, so its normalized direction is numerical noise — exclude from the fit, null coords,
-    # count. The eps-guarded L2-normalize itself can't 0/0; Euclidean never NaNs from a zero row.
-    pre_norm = np.linalg.norm(Xr, axis=1)
-    valid = pre_norm > DEGENERATE_NORM_THRESHOLD
-    n_degenerate = int((~valid).sum())
-    if n_degenerate:
-        print(f"Warning: {n_degenerate} unique vector(s) near-zero norm post-PCA "
-              f"(centered-PCA residual ≈ dataset mean) — excluded from the UMAP fit, null coords.")
-    n_valid = int(valid.sum())
-    if n_valid < min_required:
-        print(f"Warning: Not enough non-degenerate vectors for UMAP "
-              f"(required {min_required}, valid {n_valid}) — writing empty output.")
-        create_empty_umap_output(KEY_COL, args.umap_components, output_path)
-        create_empty_skipped_summary(args.output_dir,
-                                     "UMAP analysis skipped due to insufficient non-degenerate vectors.")
-        return
+    if result is None:
+        try:
+            result = _run_embedding_cpu(pf, D, n_clonotypes, min_required, args, output_path)
+        except _EmptyEmbeddingResult:
+            return
 
-    # Normalize only the valid (non-degenerate) rows we actually fit/transform — avoids dividing a
-    # near-zero residual by eps and amplifying numerical noise into rows we'd then discard.
-    Xn_valid = l2_normalize(Xr[valid])
-
-    umap_model, run_type = create_umap_model(
-        args.umap_backend, args.umap_components, args.umap_neighbors, args.umap_min_dist)
-
-    print(f"Running UMAP on {n_valid} non-degenerate unique vectors "
-          f"(L2-normalized, Euclidean ≡ cosine)...")
-    coords_valid = run_embedding_umap(Xn_valid, umap_model, run_type, args)
-
-    # Degenerate uniques get NaN coords; assemble the full unique-coord matrix, then broadcast to every
-    # clonotype via the dedup inverse index. NaN rows surface as null coords downstream.
-    coords_unique = np.full((n_unique, args.umap_components), np.nan, dtype=np.float64)
-    coords_unique[valid] = coords_valid
-    coords_all = coords_unique[inv]
-
+    keys, coords, n_degenerate, k_pca = result
     print(f"Embedding UMAP summary: model={args.embedding_model or '(unknown)'}, mode=embedding, "
-          f"clonotypes={n_clonotypes}, unique={n_unique}, PCA k={k_pca}, "
-          f"degenerate-excluded={n_degenerate}")
+          f"clonotypes={n_clonotypes}, PCA k={k_pca}, degenerate-excluded={n_degenerate}")
+    write_embedding_outputs(args, keys, coords, output_path,
+                            n_clonotypes=n_clonotypes, k_pca=k_pca, n_degenerate=n_degenerate)
 
-    write_embedding_outputs(args, keys, coords_all, output_path,
-                            n_clonotypes=n_clonotypes, n_unique=n_unique, k_pca=k_pca,
-                            n_degenerate=n_degenerate)
-
-    # Peak memory across the whole embedding run (matrix load + dedup + PCA + UMAP). Reported so the
-    # mem control can be sized to the actual N x D footprint, and to calibrate any backend cap.
+    # Peak memory across the whole embedding run. Reported so the mem control can be calibrated to the
+    # actual (now N-independent) footprint — a fit-sample-bounded peak, not the old N x D load.
     print(f"Peak memory (RSS) for embedding run: {_peak_rss_gib():.2f} GiB "
-          f"(N={n_clonotypes}, unique={n_unique}, D={D}, PCA backend fit + UMAP).")
+          f"(N={n_clonotypes}, D={D}, "
+          f"{'GPU fit-on-all + streamed load' if used_gpu else 'CPU streamed sample + batched transform'}).")
 
 
-def write_embedding_outputs(args, keys, coords_all, output_path, n_clonotypes, n_unique, k_pca,
+def write_embedding_outputs(args, keys, coords_all, output_path, n_clonotypes, k_pca,
                             n_degenerate):
     """Write the UMAP coordinates TSV (clonotypeKey, UMAP1, UMAP2, …) and the processing-log summary.
 
@@ -1362,7 +1441,6 @@ def write_embedding_outputs(args, keys, coords_all, output_path, n_clonotypes, n
         f.write("Embedding-mode UMAP summary\n")
         f.write(f"Embedding model: {args.embedding_model or '(unknown)'}\n")
         f.write(f"Clonotypes embedded: {n_clonotypes}\n")
-        f.write(f"Unique vectors (after dedup): {n_unique}\n")
         f.write(f"PCA components (95% variance): {k_pca}\n")
         f.write(f"Degenerate clonotypes excluded (null coords): {n_degenerate}\n")
     print(f"Embedding UMAP summary saved to {summary_path}")

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -1058,9 +1058,11 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
 # Memory handling for large inputs: the full N x D matrix is NEVER materialized. The CPU path
 # STREAMS the long-format parquet twice — once to collect a bounded, seeded fit sample
 # (~max_sequences x D), once to project every clonotype through the fitted PCA/UMAP in batches — so
-# peak memory is bounded by the fit sample, independent of N. The GPU path (G2) streams the load
-# straight into a device array (host stays bounded) and keeps cuML's fit-on-all behaviour unchanged.
-# Exact-duplicate vectors are NOT de-duplicated before the fit to avoid memory scaling.
+# its peak memory is bounded by the fit sample, independent of N. The GPU path streams through cuML
+# IncrementalPCA (partial_fit on ~100k-clonotype batches), so the raw N x D matrix is never resident on
+# the device either; there only the reduced N x k array and the fit-on-all UMAP scale with N. The
+# pre-PCA exact-duplicate dedup was dropped to avoid memory scaling; the GPU path instead collapses
+# exact duplicates AFTER PCA, on the small reduced vectors, right before the UMAP fit.
 
 # Fixed, data-derived batch size for the streaming reads: 4M long-format rows per pyarrow batch.
 # Deliberately NOT scaled by the allocated memory — a fixed batch keeps assembly deterministic and the
@@ -1466,10 +1468,11 @@ def run_embedding_mode(args, output_path):
                             n_clonotypes=n_clonotypes, k_pca=k_pca, n_degenerate=n_degenerate)
 
     # Peak memory across the whole embedding run. Reported so the mem control can be calibrated to the
-    # actual (now N-independent) footprint — a fit-sample-bounded peak, not the old N x D load.
+    # actual footprint: the CPU path is fit-sample-bounded (independent of N); the GPU path scales with
+    # the reduced N x k array + the IncrementalPCA batches (never the raw N x D load).
     print(f"Peak memory (RSS) for embedding run: {_peak_rss_gib():.2f} GiB "
           f"(N={n_clonotypes}, D={D}, "
-          f"{'GPU fit-on-all + streamed load' if used_gpu else 'CPU streamed sample + batched transform'}).")
+          f"{'GPU streamed IncrementalPCA + fit-on-all UMAP' if used_gpu else 'CPU streamed sample + batched transform'}).")
 
 
 def write_embedding_outputs(args, keys, coords_all, output_path, n_clonotypes, k_pca,

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -1067,6 +1067,13 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
 # per-batch footprint constant regardless of the RAM the backend granted.
 EMBEDDING_STREAM_BATCH_ROWS = 4_000_000
 
+# GPU IncrementalPCA fit batch: number of clonotypes per partial_fit call. Decoupled from the parquet
+# stream granularity (a 4M-row read yields ~4M/D clonotypes) by buffering whole-clonotype blocks up to
+# this target. Fixed (not memory-scaled) so the incremental-SVD result is reproducible across backends;
+# must stay >= the PCA component count (n_components <= batch rows), which holds by a wide margin
+# (100k >> SVD_MAX_COMPONENTS=500).
+GPU_PCA_FIT_BATCH = 100_000
+
 
 class _EmptyEmbeddingResult(Exception):
     """Signals that an embedding path already wrote the empty output files and processing should
@@ -1281,34 +1288,64 @@ def _run_embedding_cpu(pf, D, n_clonotypes, min_required, args, output_path):
 
 
 def _run_embedding_gpu(pf, D, n_clonotypes, min_required, args, output_path):
-    """GPU path: stream the long-format parquet straight into a preallocated device array (the
-    host never holds more than one batch — the eager host-RAM peak is gone), then keep cuML's
-    fit-on-all behaviour unchanged: cuPCA fit+transform on ALL clonotypes, cuML UMAP fit_transform on
-    all. Returns (keys, coords, n_degenerate, k_pca). Raises _EmptyEmbeddingResult for too-few valid
-    vectors; raises on any GPU/CUDA error so the caller can fall back to the CPU streaming path."""
+    """GPU path: stream the long-format parquet through cuML IncrementalPCA so the full N x D matrix is
+    NEVER resident on the device (the old fit-on-all cuPCA held it whole and OOM'd at scale). Two passes
+    over the parquet: pass 1 partial_fit IncrementalPCA on ~GPU_PCA_FIT_BATCH-clonotype buffers (device
+    memory bounded to one batch + the components); pass 2 re-stream and transform every clonotype into
+    the reduced N x k on device. Then cuML UMAP fit_transform on all non-degenerate reduced points —
+    still fit-on-all, but on the small reduced matrix rather than the raw embeddings. Returns
+    (keys, coords, n_degenerate, k_pca). Raises _EmptyEmbeddingResult for too-few valid vectors; raises
+    on any GPU/CUDA error so the caller can fall back to the CPU streaming path."""
     import cupy as cp
     import cuml  # noqa: F401
-    from cuml.decomposition import PCA as cuPCA
+    from cuml.decomposition import IncrementalPCA as cuIncrementalPCA
 
-    Xd = cp.empty((n_clonotypes, D), dtype=cp.float32)
+    ncomp = min(SVD_MAX_COMPONENTS, n_clonotypes - 1, D)
+
+    # --- Pass 1: streaming centered IncrementalPCA. Whole-clonotype blocks are buffered on the host to
+    #     ~GPU_PCA_FIT_BATCH, then moved to the device one batch at a time for partial_fit. One full
+    #     batch is held back so the FINAL partial_fit is never a sub-batch remainder (guaranteeing every
+    #     batch has >= ncomp rows); an input below one batch is fit in a single call. ---
+    ipca = cuIncrementalPCA(n_components=ncomp)
+    print(f"Fitting centered IncrementalPCA (RAPIDS cuML) on ALL clonotypes, streaming in "
+          f"~{GPU_PCA_FIT_BATCH}-clonotype batches (GPU)...")
+    start_pca = time.time()
+    n_batches = 0
+    prev, buf, buf_rows = None, [], 0
+    for _, mat in _stream_clonotypes(pf, args.key_col, args.dim_col, args.value_col, D):
+        buf.append(mat)
+        buf_rows += mat.shape[0]
+        if buf_rows >= GPU_PCA_FIT_BATCH:
+            block = np.concatenate(buf)
+            if prev is not None:
+                ipca.partial_fit(cp.asarray(prev))
+                n_batches += 1
+            prev, buf, buf_rows = block, [], 0
+    remainder = np.concatenate(buf) if buf else None
+    tail = remainder if prev is None else (prev if remainder is None
+                                           else np.concatenate([prev, remainder]))
+    if tail is not None:
+        ipca.partial_fit(cp.asarray(tail))
+        n_batches += 1
+
+    k_pca = min(_select_k_for_variance(cp.asnumpy(ipca.explained_variance_ratio_)), ncomp)
+    _mark_exec('svd', 'GPU', 'cuML IncrementalPCA-95% (embedding mode, streamed fit)')
+    print(f"Centered IncrementalPCA: {D} → {k_pca} components (95% variance, cap {SVD_MAX_COMPONENTS}) "
+          f"over {n_batches} batch(es) in {time.time() - start_pca:.2f}s "
+          f"(host peak RSS {_peak_rss_gib():.2f} GiB).")
+
+    # --- Pass 2: re-stream and transform every clonotype into the reduced N x k on device. This N x k
+    #     matrix (k <= SVD_MAX_COMPONENTS) is the only large device array now — never the raw N x D. ---
+    Xr = cp.empty((n_clonotypes, k_pca), dtype=cp.float32)
     keys = np.empty(n_clonotypes, dtype=object)
     g = 0
     for ks, mat in _stream_clonotypes(pf, args.key_col, args.dim_col, args.value_col, D):
         b = mat.shape[0]
-        Xd[g:g + b] = cp.asarray(mat)
+        Xr[g:g + b] = ipca.transform(cp.asarray(mat))[:, :k_pca]
         keys[g:g + b] = ks
         g += b
-    print(f"Streamed {g} clonotypes into VRAM ({Xd.nbytes / 1024**3:.2f} GiB on device; "
-          f"host peak RSS {_peak_rss_gib():.2f} GiB).")
-
-    # Centered PCA on ALL clonotypes (device) — unchanged fit-on-all behaviour.
-    ncomp = min(SVD_MAX_COMPONENTS, n_clonotypes - 1, D)
-    print("Fitting centered PCA (RAPIDS cuML, svd_solver='full') on ALL clonotypes (GPU)...")
-    pca = cuPCA(n_components=ncomp, svd_solver='full').fit(Xd)
-    k_pca = min(_select_k_for_variance(cp.asnumpy(pca.explained_variance_ratio_)), ncomp)
-    Xr = pca.transform(Xd)[:, :k_pca]
-    _mark_exec('svd', 'GPU', 'cuML PCA-95% (embedding mode, streamed load)')
-    print(f"Centered PCA: {D} → {k_pca} components (95% variance, cap {SVD_MAX_COMPONENTS}).")
+    print(f"Transformed {g} clonotypes to the reduced {k_pca}-d space "
+          f"({Xr.nbytes / 1024**3:.2f} GiB on device).")
 
     # Degenerate detection + eps-guarded L2-normalize on device (mirrors l2_normalize).
     pre_norm = cp.linalg.norm(Xr, axis=1)
@@ -1325,16 +1362,37 @@ def _run_embedding_gpu(pf, D, n_clonotypes, min_required, args, output_path):
                                      "UMAP analysis skipped due to insufficient non-degenerate vectors.")
         raise _EmptyEmbeddingResult()
     Xn = Xr[valid] / cp.maximum(pre_norm[valid][:, None], 1e-12)
+    del Xr, pre_norm   # free the reduced matrix before dedup + UMAP
+
+    # Collapse EXACT-duplicate reduced vectors before the UMAP fit. Identical embeddings map to an
+    # identical PCA value (PCA is a deterministic linear map), and cuML's GPU UMAP places zero-distance
+    # duplicate points erratically (scattered artefacts).
+    Xn_host = cp.asnumpy(Xn)
+    del Xn
+    uniq, inv = np.unique(Xn_host, axis=0, return_inverse=True)
+    inv = inv.ravel()   # numpy 2.x can return a 2-D inverse for axis=0; flatten to (n_valid,)
+    n_unique = int(uniq.shape[0])
+    if n_unique < Xn_host.shape[0]:
+        print(f"Collapsing {Xn_host.shape[0]} → {n_unique} unique reduced vectors "
+              f"({Xn_host.shape[0] - n_unique} exact duplicates) before the GPU UMAP fit.")
+    if n_unique < min_required:
+        print(f"Warning: Not enough unique non-degenerate vectors for UMAP "
+              f"(required {min_required}, unique {n_unique}) — writing empty output.")
+        create_empty_umap_output(KEY_COL, args.umap_components, output_path)
+        create_empty_skipped_summary(args.output_dir,
+                                     "UMAP analysis skipped due to insufficient unique vectors.")
+        raise _EmptyEmbeddingResult()
 
     umap_model, run_type = create_umap_model(args.umap_backend, args.umap_components,
                                              args.umap_neighbors, args.umap_min_dist)
     if run_type != 'gpu':
         raise RuntimeError("cuML UMAP unavailable despite a usable GPU PCA — deferring to CPU path.")
-    print(f"Running UMAP (GPU, fit_transform on all {n_valid} non-degenerate vectors)...")
+    print(f"Running UMAP (GPU, fit_transform on {n_unique} unique non-degenerate vectors)...")
     start_umap = time.time()
-    coords_valid = cp.asnumpy(umap_model.fit_transform(Xn))
-    _mark_exec('umap', 'GPU', 'cuML UMAP.fit_transform() returned (embedding mode, streamed load)')
+    uniq_coords = cp.asnumpy(umap_model.fit_transform(cp.asarray(uniq)))
+    _mark_exec('umap', 'GPU', 'cuML UMAP.fit_transform() returned (embedding mode, dedup + streamed fit)')
     print(f"UMAP (GPU) completed in {time.time() - start_umap:.2f}s.")
+    coords_valid = uniq_coords[inv]   # broadcast each unique's coords back to every valid clonotype
 
     coords = np.full((n_clonotypes, args.umap_components), np.nan, dtype=np.float64)
     coords[cp.asnumpy(valid)] = coords_valid

--- a/software/umap/src/requirements.txt
+++ b/software/umap/src/requirements.txt
@@ -3,6 +3,7 @@ polars-lts-cpu==1.33.1
 numpy==2.0.2
 scikit-learn==1.7.2
 scipy==1.16.2
+pyarrow==19.0.1
 umap-learn==0.5.7
 torch==2.7.0
 cudf-cu12==25.4.0; platform_system == "Linux" and platform_machine == "x86_64"

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -92,6 +92,8 @@ wf.body(func(args) {
 		processInputs.keyCol = keyCol
 		processInputs.dimCol = embSpec.axesSpec[1].annotations["pl7.app/label"]
 		processInputs.valueCol = embSpec.annotations["pl7.app/label"]
+		// Embedding vector length D — passed to main.py's streaming loader as --dims (avoids a scan).
+		processInputs.dims = embSpec.annotations["pl7.app/embedding/length"]
 	} else {
 		processInputs.sequencesRef = sequencesRef
 		processInputs.sequenceType = args.sequenceType

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -61,6 +61,7 @@ self.body(func(inputs) {
 			keyCol: inputs.keyCol,
 			dimCol: inputs.dimCol,
 			valueCol: inputs.valueCol,
+			dims: inputs.dims,
 			umap_neighbors: umap_neighbors,
 			umap_min_dist: umap_min_dist
 		}, {

--- a/workflow/src/resource-formula.lib.tengo
+++ b/workflow/src/resource-formula.lib.tengo
@@ -20,8 +20,9 @@ f := exec.formula
 // Embeddings: sized off the parquet byte size (f.size).
 // onCPU.ram: main.py streams the embedding matrix (never loads the full N x D), so the CPU peak is
 // bounded by the fit sample (~max_sequences x D) plus the PCA fit, independent of N — hence a floor +
-// small size margin, NOT the old 12x eager-load multiple. onGPU.vram stays size-scaled: the GPU
-// path keeps cuML's fit-on-all, so the full matrix still lives in VRAM.
+// small size margin, NOT the old 12x eager-load multiple. onGPU.vram stays size-scaled: the reduced
+// N x k device array + the per-batch IncrementalPCA buffers still grow with input size (the raw N x D
+// matrix is never resident on the device).
 resourcesEmbeddings := func(builder) {
     size := f.size("input")
     return builder.resources({

--- a/workflow/src/resource-formula.lib.tengo
+++ b/workflow/src/resource-formula.lib.tengo
@@ -18,12 +18,16 @@ exec := import("@platforma-sdk/workflow-tengo:exec")
 f := exec.formula
 
 // Embeddings: sized off the parquet byte size (f.size).
+// onCPU.ram: main.py streams the embedding matrix (never loads the full N x D), so the CPU peak is
+// bounded by the fit sample (~max_sequences x D) plus the PCA fit, independent of N — hence a floor +
+// small size margin, NOT the old 12x eager-load multiple. onGPU.vram stays size-scaled: the GPU
+// path keeps cuML's fit-on-all, so the full matrix still lives in VRAM.
 resourcesEmbeddings := func(builder) {
     size := f.size("input")
     return builder.resources({
         onCPU: {
             cpu: size.dividedBy(f.gib(4)).between(4, 16).staticFallback(8),
-            ram: size.times(12).plus(f.gib(8)).between(f.gib(16), f.gib(128)).staticFallback(f.gib(64))
+            ram: size.plus(f.gib(12)).between(f.gib(16), f.gib(48)).staticFallback(f.gib(20))
         },
         onGPU: {
             cpu: 4,

--- a/workflow/src/resource-formula.test.tengo
+++ b/workflow/src/resource-formula.test.tengo
@@ -44,10 +44,11 @@ TestResourcesEmbeddings := func() {
     test.isEqual(16, _eval(spec.onCPU.cpu, F, 100 * _gib(1), 0))    // huge -> cap
     test.isEqual(8,  f.fallbackOf(spec.onCPU.cpu))
 
-    // onCPU.ram = 12*size + 8GiB bounded to [16, 128] GiB; fallback 64GiB
-    test.isEqual(_gib(16),  _eval(spec.onCPU.ram, F, 0, 0))          // floor
-    test.isEqual(_gib(128), _eval(spec.onCPU.ram, F, 100 * _gib(1), 0)) // cap
-    test.isEqual(_gib(64),  f.fallbackOf(spec.onCPU.ram))
+    // onCPU.ram = size + 12GiB bounded to [16, 48] GiB; fallback 20GiB (streaming: peak is fit-sample
+    // bounded, independent of N — no longer the old 12x eager-load multiple)
+    test.isEqual(_gib(16), _eval(spec.onCPU.ram, F, 0, 0))          // floor (0 + 12GiB -> floored to 16)
+    test.isEqual(_gib(48), _eval(spec.onCPU.ram, F, 100 * _gib(1), 0)) // cap
+    test.isEqual(_gib(20), f.fallbackOf(spec.onCPU.ram))
 
     // onGPU.cpu is a fixed core count (CPU-fallback safety on the GPU host).
     test.isEqual(4, spec.onGPU.cpu)
@@ -112,8 +113,8 @@ TestApplyRoutesByInputMode := func() {
     // embedding -> resourcesEmbeddings: onCPU.ram reacts to SIZE, ignores lineCount.
     emb := _mock()
     rf.apply(emb, {}, "embedding")
-    test.isEqual(_gib(128), _eval(emb.calls.spec.onCPU.ram, "input.parquet", 100 * _gib(1), 0)) // size -> cap
-    test.isEqual(_gib(16),  _eval(emb.calls.spec.onCPU.ram, "input.parquet", 0, 1000000000))    // lineCount ignored -> floor
+    test.isEqual(_gib(48), _eval(emb.calls.spec.onCPU.ram, "input.parquet", 100 * _gib(1), 0)) // size -> cap
+    test.isEqual(_gib(16), _eval(emb.calls.spec.onCPU.ram, "input.parquet", 0, 1000000000))    // lineCount ignored -> floor
 
     // sequence-features -> resourcesSeqFeatures: onCPU.ram reacts to LINECOUNT, ignores size.
     seq := _mock()

--- a/workflow/src/umap-calculation.tpl.tengo
+++ b/workflow/src/umap-calculation.tpl.tengo
@@ -1,4 +1,4 @@
-//tengo:hash_override 16D7E7CE-5B0D-4D2C-A8BF-6909B926FA9D
+//tengo:hash_override BA521FD9-9224-4406-87E8-F80B3BDD6627
 
 self := import("@platforma-sdk/workflow-tengo:tpl")
 exec := import("@platforma-sdk/workflow-tengo:exec")
@@ -34,6 +34,13 @@ self.body(func(args) {
             arg("--umap-neighbors").arg(string(umap_neighbors)).
             arg("--umap-min-dist").arg(string(umap_min_dist)).
             arg("--n-jobs").argExpr("{system.cpu}")
+
+        // Embedding vector length D (pl7.app/embedding/length): lets the streaming loader resolve D
+        // without a scan. Undefined if the column lacks the annotation — main.py then infers it from
+        // the first row group.
+        if !is_undefined(args.dims) {
+            builder = builder.arg("--dims").arg(args.dims)
+        }
 
         // Embedding model: logged to the processing log for provenance. Undefined if the column
         // lacks the domain key — omit the flag rather than pass an empty string.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes embedding-mode UMAP to use a bounded CPU fit sample and batched projection, propagates embedding dimensionality through the workflow, and updates resource sizing and SDK dependencies.
- **Embedding matrix:** Long-format Parquet data containing one value for each clonotype and embedding dimension; loading changes from eager N×D materialization to batched assembly.
- **Embedding dimension (D):** The vector length from `pl7.app/embedding/length`; it is now passed as `--dims`, with first-row-group inference as a fallback.
- **Fit sample:** A seeded subset bounded by `--max-sequences`; CPU PCA and UMAP are now fitted on this sample before all clonotypes are transformed.
- **PCA:** Centered dimensionality reduction retaining 95% explained variance; CPU fitting becomes sample-bounded while GPU fitting remains fit-on-all.
- **UMAP transform:** Out-of-sample projection of each CPU batch through fitted PCA and UMAP models; GPU behavior remains full-device fit/transform.
- **Degenerate vector:** A near-zero post-PCA vector; these vectors now receive null coordinates and are excluded from UMAP fitting.
- **Resource formula:** Data-driven CPU RAM sizing for embedding mode is lowered from an eager-load multiplier to a 16–48 GiB range.
- **PColumn:** Platforma typed column abstraction; its local TypeScript alias now permits undefined column values following the SDK update.
- **Dependency catalog:** Workspace SDK, tooling, and Python runtime packages are upgraded and the lockfile is regenerated.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the CPU embedding output is streamed or otherwise bounded, because huge inputs can still exhaust the newly reduced RAM allocation.

Input feature matrices are streamed, but all output keys and coordinates remain resident and are copied repeatedly during concatenation, Python-list conversion, and DataFrame creation, so peak CPU memory still grows with clonotype count.

**Files Needing Attention:** software/umap/src/main.py and workflow/src/resource-formula.lib.tengo
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/umap/src/main.py | Introduces two-pass CPU streaming and streamed GPU loading, but the CPU output stage still accumulates and copies O(N) data, leaving a large-input OOM path. |
| workflow/src/main.tpl.tengo | Propagates the embedding-length annotation and exported matrix metadata into the calculation template. |
| workflow/src/umap-calculation.tpl.tengo | Adds conditional forwarding of embedding dimensions to the Python executable. |
| workflow/src/resource-formula.lib.tengo | Substantially lowers CPU embedding RAM based on streaming, although the remaining N-scaled output materialization undermines the stated bound. |
| workflow/src/resource-formula.test.tengo | Updates formula expectations consistently with the new CPU RAM floor, cap, and fallback. |
| model/src/index.ts | Broadens the local PColumn value type to accommodate undefined values after the SDK update. |
| pnpm-workspace.yaml | Upgrades Platforma SDK, build tooling, helper, and Python runtime catalog versions. |
| pnpm-lock.yaml | Regenerates resolved dependencies for the workspace catalog upgrades. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Long-format embedding Parquet] --> B[Stream clonotype batches]
  B --> C[Seeded bounded fit sample]
  C --> D[Fit centered PCA]
  D --> E[Fit CPU UMAP]
  B --> F[Transform each batch]
  D --> F
  E --> F
  F --> G[Accumulate all keys and coordinates]
  G --> H[Materialize TSV output]
  A --> I[GPU device matrix]
  I --> J[Fit-on-all cuML PCA and UMAP]
  J --> H
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asoftware%2Fumap%2Fsrc%2Fmain.py%3A1270-1277%0A**Output%20accumulation%20remains%20unbounded**%0A%0AWhen%20a%20CPU%20embedding%20run%20contains%20enough%20clonotypes%2C%20this%20loop%20retains%20every%20key%20and%20coordinate%20batch%2C%20then%20duplicates%20them%20with%20%60concatenate%60%2F%60vstack%60%20and%20again%20as%20Python%20lists%20and%20a%20Polars%20frame%2C%20causing%20the%20process%20to%20exhaust%20the%20newly%20capped%2048%20GiB%20allocation%20despite%20the%20input%20matrix%20being%20streamed.%0A%0A&repo=platforma-open%2Fclonotype-space&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/umap/src/main.py:1270-1277
**Output accumulation remains unbounded**

When a CPU embedding run contains enough clonotypes, this loop retains every key and coordinate batch, then duplicates them with `concatenate`/`vstack` and again as Python lists and a Polars frame, causing the process to exhaust the newly capped 48 GiB allocation despite the input matrix being streamed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/clonotype-space/commit/075792e352a1c021e7a12e7481843625cfb28294) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47527678)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->