### PR TITLE
MILAB-6501: review fixes — restore CPU unique-vectors guard, fix --dims error, correct stale GPU comments

### DIFF
--- a/.changeset/clonotype-space-embedding-streaming.md
+++ b/.changeset/clonotype-space-embedding-streaming.md
@@ -10,11 +10,15 @@ Embedding mode: stream the embedding matrix instead of eager-loading it, so larg
 The `--encoding embedding` path in `main.py` now streams the long-format parquet in fixed 4M-row batches
 rather than materializing the full N×D matrix. The CPU path collects a bounded, seeded fit sample
 (~`--max-sequences` vectors), fits PCA + UMAP on it, then re-streams to project every clonotype in
-batches; the GPU path streams the load straight into VRAM and keeps cuML's fit-on-all behaviour. Peak
-memory is now bounded by the fit sample, independent of the clonotype count.
+batches; the GPU path streams cuML `IncrementalPCA` over the same batches, then re-streams to transform
+every clonotype into the reduced N×k space on device. Neither path holds the raw N×D matrix. CPU peak is
+now the fit sample plus the O(N) output coordinates, dominated by the N-independent PCA fit.
 
 The workflow passes the embedding length as `--dims` (from the `pl7.app/embedding/length` annotation),
 and the embedding RAM request is lowered to match the streamed footprint. Global exact-duplicate dedup
 is dropped and the fit sample is drawn over all clonotypes; both shift coordinates slightly versus prior
-builds (a memory fix — output already varies across backends and machines). PCA/UMAP parameters and
-sample sizes are unchanged. Sequence-feature mode is untouched.
+builds (a memory fix — output already varies across backends and machines). The GPU path still collapses
+duplicate reduced vectors before its UMAP fit, since cuML scatters zero-distance points; the CPU path
+relies on umap-learn collapsing them naturally and guards only the pathological case of fewer distinct
+vectors than `--umap-neighbors` + 1. PCA/UMAP parameters and sample sizes are unchanged. Sequence-feature
+mode is untouched.

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -1106,20 +1106,35 @@ def _clonotype_count(pf, D):
 def _stream_clonotypes(pf, key_col, dim_col, value_col, D, batch_rows=EMBEDDING_STREAM_BATCH_ROWS):
     """Yield (keys, matrix) blocks of whole clonotypes, assembled from contiguous long-format rows and
     holding back the trailing clonotype that may continue in the next batch. Memory bounded to ~one
-    batch. Copied from embedding-clustering; keep the guards in sync."""
+    batch.
+
+    Requires the parquet to be clonotype-blocked. That holds by contract, not by luck: xsv.exportFrame
+    emits axis-sorted rows ("read_frame output is already sorted by axes (PFrame PTable contract)" --
+    sdk/workflow-tengo/src/pframes/xsv-export-pframe.tpl.tengo), and the embedding column's axes are
+    [clonotypeKey, embeddingDim], so all of a clonotype's D rows are contiguous. If that contract ever
+    changes this loader must go back to an order-independent scatter over the whole file."""
     def build(ks, ds, vs):
         # np.unique -> distinct keys `uk` (sorted) + `inv` (per-row index into uk). Scattering
         # mat[inv, ds] = vs drops each value into its (clonotype, embeddingDim) cell, so row order
         # within the block does not matter.
         uk, inv = np.unique(ks, return_inverse=True)
-        # Row-count guard: each clonotype must have exactly D contiguous rows.
-        if (np.bincount(inv) != D).any():
-            raise ValueError("a clonotype did not have exactly D contiguous rows -- the embedding "
-                             "matrix is not clonotype-blocked (the streaming loader needs contiguous rows).")
-        # Dimension-range guard: embeddingDim must be a 0..D-1 index.
+        # Dimension-range guard first: a wrong D is the likeliest cause of a row-count mismatch, and
+        # this check can name it outright. Fires when the declared D is too SMALL for the data.
         if ds.min() < 0 or ds.max() >= D:
             raise ValueError(f"embeddingDim out of range [0, {D}); saw {int(ds.min())}..{int(ds.max())} "
-                             f"-- pass the correct --dims (the pl7.app/embedding/length annotation).")
+                             f"-- --dims / the pl7.app/embedding/length annotation disagrees with the "
+                             f"data (its true vector length is at least {int(ds.max()) + 1}).")
+        # Row-count guard: each clonotype must have exactly D rows in this block. Report the observed
+        # count -- it IS the real vector length, which is what distinguishes the two causes that both
+        # land here: a wrong/stale pl7.app/embedding/length, or a matrix that is not clonotype-blocked.
+        counts = np.bincount(inv)
+        if (counts != D).any():
+            obs = int(counts[int(np.argmax(counts != D))])
+            raise ValueError(f"a clonotype has {obs} row(s), expected D={D} -- either --dims / the "
+                             f"pl7.app/embedding/length annotation disagrees with the data (its true "
+                             f"vector length looks like {obs}), or the embedding matrix is not "
+                             f"clonotype-blocked (the streaming loader needs each clonotype's rows "
+                             f"contiguous).")
         # Completeness: NaN-fill, scatter, require no cell left unset -- catches a duplicated dim (hence
         # a missing dim -> an unfilled hole) and any NaN in the value column.
         mat = np.full((uk.shape[0], D), np.nan, dtype=np.float32)

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -1266,10 +1266,27 @@ def _run_embedding_cpu(pf, D, n_clonotypes, min_required, args, output_path):
 
     umap_model, _ = create_umap_model('sklearn', args.umap_components, args.umap_neighbors,
                                       args.umap_min_dist)
+    Xn_fit = l2_normalize(Xr_fit[valid_fit])
+
+    # Unique-vector guard. Below n_neighbors+1 DISTINCT vectors every neighbour sits at distance 0, so
+    # umap-learn has no local structure to anchor the layout: it still separates the distinct vectors,
+    # but scatters each duplicate group over a radius comparable to the distance between genuinely
+    # different vectors — inventing spread the data does not have. Bail to an empty output, as
+    # _run_embedding_gpu does for the same case; both dedup post-L2-normalize so the counts agree.
+    # NOT the dropped global dedup: this reads only the fit sample (<= max_sequences x k), never all N.
+    n_unique_fit = int(np.unique(Xn_fit, axis=0).shape[0])
+    if n_unique_fit < min_required:
+        print(f"Warning: Not enough unique non-degenerate vectors in the fit sample for UMAP "
+              f"(required {min_required}, unique {n_unique_fit}) — writing empty output.")
+        create_empty_umap_output(KEY_COL, args.umap_components, output_path)
+        create_empty_skipped_summary(args.output_dir,
+                                     "UMAP analysis skipped due to insufficient unique vectors.")
+        raise _EmptyEmbeddingResult()
+
     print(f"Fitting UMAP on {n_valid_fit} non-degenerate fit-sample vectors "
-          f"(L2-normalized, Euclidean ≡ cosine)...")
+          f"({n_unique_fit} unique; L2-normalized, Euclidean ≡ cosine)...")
     start_umap = time.time()
-    _fit_umap_cpu(umap_model, l2_normalize(Xr_fit[valid_fit]))
+    _fit_umap_cpu(umap_model, Xn_fit)
     print(f"UMAP fit completed in {time.time() - start_umap:.2f}s.")
 
     # --- Pass B: project every clonotype in batches (out-of-sample transform) ---

--- a/software/umap/src/main.py
+++ b/software/umap/src/main.py
@@ -1055,12 +1055,19 @@ def run_cpu_pipeline(args, df_valid, sequences_all, umap_model):
 # Centered PCA removes ESM-2's large non-discriminative shared mean, so the post-PCA
 # L2-normalize + Euclidean (≡ cosine ranking) then measures the mean-removed residuals.
 #
-# Memory handling for large inputs: the full N x D matrix is NEVER materialized. The CPU path
-# STREAMS the long-format parquet twice — once to collect a bounded, seeded fit sample
-# (~max_sequences x D), once to project every clonotype through the fitted PCA/UMAP in batches — so
-# peak memory is bounded by the fit sample, independent of N. The GPU path (G2) streams the load
-# straight into a device array (host stays bounded) and keeps cuML's fit-on-all behaviour unchanged.
-# Exact-duplicate vectors are NOT de-duplicated before the fit to avoid memory scaling.
+# Memory handling for large inputs: the full N x D matrix is NEVER materialized. Both paths STREAM the
+# long-format parquet twice.
+#   CPU: pass A collects a bounded, seeded fit sample (~max_sequences x D) and fits PCA + UMAP on it;
+#        pass B projects every clonotype through the fitted models in batches. Peak is the fit sample
+#        plus the O(N) output coordinates — NOT the old N x D load.
+#   GPU: pass 1 fits cuML IncrementalPCA on ~GPU_PCA_FIT_BATCH-clonotype batches; pass 2 transforms
+#        every clonotype into the reduced N x k_pca on device. The raw N x D never lands on the device
+#        either. The reduced matrix is then copied to the host for the duplicate collapse below.
+# Exact-duplicate handling differs by path, deliberately. The GPU path collapses duplicate reduced
+# vectors before the UMAP fit because cuML scatters zero-distance points. The CPU path does not: at any
+# normal duplication rate umap-learn's own transform lands duplicates on effectively identical
+# coordinates, so a global dedup would cost O(N) memory for nothing. It only guards the pathological
+# case of fewer distinct vectors than n_neighbors+1, where that no longer holds (see _run_embedding_cpu).
 
 # Fixed, data-derived batch size for the streaming reads: 4M long-format rows per pyarrow batch.
 # Deliberately NOT scaled by the allocated memory — a fixed batch keeps assembly deterministic and the

--- a/workflow/src/resource-formula.lib.tengo
+++ b/workflow/src/resource-formula.lib.tengo
@@ -18,10 +18,15 @@ exec := import("@platforma-sdk/workflow-tengo:exec")
 f := exec.formula
 
 // Embeddings: sized off the parquet byte size (f.size).
-// onCPU.ram: main.py streams the embedding matrix (never loads the full N x D), so the CPU peak is
-// bounded by the fit sample (~max_sequences x D) plus the PCA fit, independent of N — hence a floor +
-// small size margin, NOT the old 12x eager-load multiple. onGPU.vram stays size-scaled: the GPU
-// path keeps cuML's fit-on-all, so the full matrix still lives in VRAM.
+// onCPU.ram: main.py streams the embedding matrix (never loads the full N x D), so the CPU peak is the
+// fit sample (~max_sequences x D) plus sklearn's full-SVD fit over it, plus the O(N) output
+// coordinates. The dominant term is the fit, which is N-independent: measured ~7.4 GiB at the largest
+// reachable D (2560 = esm2-650M on concat-Fv), inside the 16 GiB floor. Hence a floor + small size
+// margin, NOT the old 12x eager-load multiple.
+// onGPU stays size-scaled: the GPU path no longer holds the raw N x D on device (it streams
+// IncrementalPCA), but it does hold the reduced N x k_pca (k_pca <= 500) plus one
+// GPU_PCA_FIT_BATCH-clonotype batch, and cuML's UMAP graph over all N points — so VRAM still grows
+// with the input, and it copies the reduced matrix to the host for the pre-UMAP duplicate collapse.
 resourcesEmbeddings := func(builder) {
     size := f.size("input")
     return builder.resources({


### PR DESCRIPTION
Review follow-ups for #111, targeting that branch so they land with it rather than after.

Scope is deliberately narrow: only things that are **wrong**, not things that could be better. The streaming rewrite itself is correct — key/coordinate alignment, the fit-sample gather, the `IncrementalPCA` batch hold-back, and the resource sizing all check out (see Verification).

## 1. Restore the unique-vectors guard on the CPU path

`run_embedding_mode` used to dedup the whole matrix and bail when fewer than `n_neighbors + 1` distinct vectors survived. The streamed CPU path drops the dedup for memory reasons, and the guard went with it — it was a rider on the dedup, not a standalone check. `_run_embedding_gpu` still has it, so the same input gave different answers depending on which backend ran.

Below `n_neighbors + 1` distinct vectors, every neighbour sits at distance 0 and umap-learn has no local structure to anchor the layout. It still separates the distinct vectors, but scatters each duplicate group over a radius comparable to the distance between genuinely different vectors. Measured on 5000 clonotypes built from 3 distinct vectors: **2273 distinct output coordinates, group radius ~9–11 against inter-group distance ~20**. That renders as diffuse blobs and invents spread the data does not have, where the GPU path writes an empty output and the UI shows "too few sequences to embed".

The new check reads only the fit sample (`<= max_sequences x k_pca`), so it does **not** reintroduce the O(N) dedup this branch removed.

Worth confirming the direction: the alternative is dropping the guard from the GPU path instead, so both scatter. Restoring on CPU matches pre-#111 behaviour, so that's what this does — but either is defensible as long as the two paths agree.

**Dropping the dedup is otherwise fine.** At normal duplication rates umap-learn collapses duplicates by itself — measured within-group scatter as a fraction of embedding scale: **4%** at 10% duplicated rows, **1%** at 50%, **0%** at 90%. The changeset's "shift coordinates slightly" is accurate for everything except the pathological case above.

## 2. Name the real cause when `--dims` disagrees with the data

`_stream_clonotypes` checked the per-clonotype row count before the dimension range, so a wrong `D` reported *"the embedding matrix is not clonotype-blocked"*. That points at row ordering, but the far likelier cause is a stale or absent `pl7.app/embedding/length` — the annotation is optional (`sequence-embeddings` emits it only for mapped models), and under the old message a wrong `--dims` was indistinguishable from a badly ordered matrix.

Now the range check runs first, and the row-count error reports the observed count — which *is* the true vector length, and is exactly what separates the two causes:

```
# declared 160, real 320
embeddingDim out of range [0, 160); saw 0..319 -- --dims / the pl7.app/embedding/length
annotation disagrees with the data (its true vector length is at least 320).

# declared 640, real 320
a clonotype has 320 row(s), expected D=640 -- either --dims / the pl7.app/embedding/length
annotation disagrees with the data (its true vector length looks like 320), or the embedding
matrix is not clonotype-blocked (the streaming loader needs each clonotype's rows contiguous).
```

This commit also replaces the docstring's *"Copied from embedding-clustering; keep the guards in sync"* — no such loader exists there; `embedding-clustering` reads the whole file with an order-independent scatter — with the contract this loader actually depends on. `xsv.exportFrame` emits axis-sorted rows (`sdk/workflow-tengo/src/pframes/xsv-export-pframe.tpl.tengo`: *"read_frame output is already sorted by axes (PFrame PTable contract)"*), and the embedding column's axes are `[clonotypeKey, embeddingDim]`, so a clonotype's `D` rows are contiguous. The assumption is sound; it just wasn't written down, and the previous loader deliberately avoided depending on it.

## 3. Correct comments describing the superseded GPU design

The GPU path was rewritten in `1337b30` to stream `IncrementalPCA`, but the comments from `68f67eb` still describe what it replaced. Three state the opposite of what the code does:

- **`main.py` module header** — *"The GPU path streams the load straight into a device array and keeps cuML's fit-on-all behaviour unchanged. Exact-duplicate vectors are NOT de-duplicated before the fit."* It's two-pass `IncrementalPCA`, and it does dedup. That last sentence is the one a reader would use to conclude both paths treat duplicates identically — precisely the divergence in item 1.
- **`resource-formula.lib.tengo`** — *"the GPU path keeps cuML's fit-on-all, so the full matrix still lives in VRAM."* This is the stated rationale for `vram = size × 8 + 2GiB`, and it's no longer true; the device holds the reduced `N × k_pca` plus one fit batch. **Formula values are unchanged** — only the rationale, which now records what is actually resident.
- **The changeset** repeats both, so they would ship to the CHANGELOG.

Also drops *"peak memory is bounded by the fit sample, independent of N"* (the output coordinates are O(N)) and the dangling `(G2)` label, and records the measured CPU peak so the 16 GiB floor has a number behind it.

## Verification

Ran the patched `main.py` end-to-end against synthetic clonotype-blocked parquets (`umap-learn` 0.5.7):

| Case | Result |
|---|---|
| 5000 clonotypes, 3 distinct vectors | empty output + "insufficient unique vectors" |
| 800 clonotypes, all distinct | 800 coordinate rows, no nulls, finite |
| Same input without `--dims` (D inferred) | byte-identical to the `--dims` run |
| Empty matrix | empty output, no crash |
| `--dims` too small / too large | both new messages, as quoted above |

`pl-tengo check` clean; all 4 `resource-formula.test.tengo` tests pass. No changeset added — the existing one already covers `.umap` and `.workflow`, the two packages touched here.

Also validated while reviewing, no change needed: worst-case CPU peak is **~7.4 GiB** at the largest reachable `D` (2560 = esm2-650M on concat-Fv) — `X_fit` 1.91 GiB plus 5.49 GiB for sklearn's full-SVD fit — comfortably inside the 16 GiB floor. The O(N) output stage is ~250 B/clonotype, so ~4 GiB at N=16M. The lowered RAM request holds.

## Out of scope, noted for later

- `resource-formula.test.tengo` is never executed: `pl-tengo test` exists, but `workflow/package.json` has no `test` script, so nothing runs it in CI. The updated expectations in #111 are correct (verified by running it manually), but they're currently unenforced.
- `_stream_clonotypes` converts the long-format key column to Python objects and `np.unique`-sorts it per batch — 1.08 s per 4M-row batch, twice per run. `Series.rle()` does the same job ~94× faster, and expresses the contiguity invariant directly. Pure performance, no behaviour change.
- The GPU duplicate collapse copies the reduced matrix to the host and lexsorts it (`2 × N × k_pca`) to remove duplicates real embeddings essentially never have. `cp.unique(..., axis=0)` would keep it on device.
- umap-learn 0.5.7 calls `check_array(force_all_finite=…)`, which newer scikit-learn removed — it hard-fails on 1.9.0. The pinned `scikit-learn==1.7.2` still accepts it, so nothing is broken now, but a future bump breaks embedding mode outright.
