### PR TITLE
MILAB-XXX: disable GPU on all levels

### DIFF
--- a/.changeset/tired-taxis-dream.md
+++ b/.changeset/tired-taxis-dream.md
@@ -1,0 +1,6 @@
+---
+"@platforma-open/milaboratories.clonotype-space.workflow": patch
+"@platforma-open/milaboratories.clonotype-space": patch
+---
+
+Disable GPU by default on all levels

--- a/workflow/src/resource-formula.lib.tengo
+++ b/workflow/src/resource-formula.lib.tengo
@@ -29,12 +29,12 @@ resourcesEmbeddings := func(builder) {
         onCPU: {
             cpu: size.dividedBy(f.gib(4)).between(4, 16).staticFallback(8),
             ram: size.plus(f.gib(12)).between(f.gib(16), f.gib(48)).staticFallback(f.gib(20))
-        },
+        }/*,
         onGPU: {
             cpu: 4,
             ram: size.times(6).plus(f.gib(2)).between(f.gib(4), f.gib(64)).staticFallback(f.gib(16)),
             vram: size.times(8).plus(f.gib(2)).between(f.gib(6), f.gib(48)).staticFallback(f.gib(16))
-        }
+        }*/
     })
 }
 
@@ -45,12 +45,12 @@ resourcesSeqFeatures := func(builder) {
         onCPU: {
             cpu: size.dividedBy(250000).between(4, 16).staticFallback(8),
             ram: size.times(4096).plus(f.gib(8)).between(f.gib(16), f.gib(128)).staticFallback(f.gib(64))
-        },
+        }/*,
         onGPU: {
             cpu: 4,
             ram: size.times(1024).plus(f.gib(2)).between(f.gib(4), f.gib(64)).staticFallback(f.gib(16)),
             vram: size.times(512).plus(f.gib(2)).between(f.gib(6), f.gib(48)).staticFallback(f.gib(16))
-        }
+        }*/
     })
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR disables automatically selected GPU resources for embeddings and sequence-feature calculations, leaving CPU profiles as their defaults. It also adds patch changesets for the workflow and block packages.
- **Resource profile** — A CPU or GPU resource specification attached to an execution builder. The data-driven embeddings and sequence-features profiles now expose only `onCPU`.
- **`onCPU`** — CPU and RAM requirements used for CPU scheduling. These profiles remain unchanged and become the only choices in the two modified resource builders.
- **`onGPU`** — CPU, RAM, and VRAM requirements used for GPU scheduling. These profiles are commented out for embeddings and sequence features, although direct mode can still provide an explicitly requested GPU profile.
- **Resource formula** — Logic deriving execution resources from input size and settings. Its default/data-driven branches now prevent GPU selection for both calculation levels.
- **Changeset** — Package-release metadata describing version impact. Patch releases are added for `@platforma-open/milaboratories.clonotype-space.workflow` and `@platforma-open/milaboratories.clonotype-space`.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The existing resource-formula tests must be updated to reflect the intentional removal of the two GPU profiles before merging.

The changed builders no longer return onGPU fields, while their current tests still dereference and compare those fields against numeric expectations, producing deterministic test failures.

**Files Needing Attention:** workflow/src/resource-formula.lib.tengo and workflow/src/resource-formula.test.tengo
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/resource-formula.lib.tengo | Removes data-driven GPU profiles from two resource builders, but leaves their existing onGPU test expectations unsatisfied. |
| .changeset/tired-taxis-dream.md | Adds matching patch-release entries and describes GPU resources as disabled by default. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aworkflow%2Fsrc%2Fresource-formula.lib.tengo%3A32-37%0A**Removed%20profiles%20break%20resource%20tests**%0A%0AWhen%20the%20resource-formula%20tests%20evaluate%20embeddings%20or%20sequence-feature%20resources%2C%20these%20builders%20omit%20%60onGPU%60%20while%20the%20tests%20still%20dereference%20and%20compare%20its%20CPU%2C%20RAM%2C%20and%20VRAM%20fields%2C%20causing%20deterministic%20test%20failures.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=platforma-open%2Fclonotype-space&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
workflow/src/resource-formula.lib.tengo:32-37
**Removed profiles break resource tests**

When the resource-formula tests evaluate embeddings or sequence-feature resources, these builders omit `onGPU` while the tests still dereference and compare its CPU, RAM, and VRAM fields, causing deterministic test failures.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-XXX: disable GPU on all levels"](https://github.com/platforma-open/clonotype-space/commit/63052ff8920213bf7d99e80eb7b0fe8e1c118679) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49642637)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->