### PR TITLE
MILAB-6722: run the resource-formula unit test in CI

### DIFF
--- a/.changeset/run-resource-formula-test.md
+++ b/.changeset/run-resource-formula-test.md
@@ -1,0 +1,16 @@
+---
+"@platforma-open/milaboratories.clonotype-space.workflow": patch
+---
+
+Run the resource-formula unit test in CI.
+
+`resource-formula.test.tengo` was committed complete but had never executed: the
+workflow package had no `test` script, so nothing invoked it. Run for the first
+time, 2 of its 4 tests failed — both asserting `spec.onGPU.cpu` against the
+`onGPU` block that 63052ff commented out of `resource-formula.lib.tengo`. Tengo
+yields `undefined` for `undefined[key]` instead of erroring, so the assertions
+compared 4 against `<undefined>`.
+
+The stale GPU assertions are removed and the script added, so the four remaining
+tests now guard the CPU formulas against drift. Restore the GPU assertions
+alongside the lib block whenever GPU is re-enabled.

--- a/workflow/package.json
+++ b/workflow/package.json
@@ -8,7 +8,8 @@
     "build": "shx rm -rf dist && pl-tengo build",
     "format": "/usr/bin/env emacs --script ./format.el || echo 'No emacs.'",
     "do-pack": "shx rm -f *.tgz && pnpm pack && shx mv *.tgz package.tgz",
-    "check": "pl-tengo check"
+    "check": "pl-tengo check",
+    "test": "pl-tengo test ./src"
   },
   "dependencies": {
     "@platforma-open/milaboratories.clonotype-space.umap": "workspace:*",

--- a/workflow/src/resource-formula.test.tengo
+++ b/workflow/src/resource-formula.test.tengo
@@ -50,18 +50,11 @@ TestResourcesEmbeddings := func() {
     test.isEqual(_gib(48), _eval(spec.onCPU.ram, F, 100 * _gib(1), 0)) // cap
     test.isEqual(_gib(20), f.fallbackOf(spec.onCPU.ram))
 
-    // onGPU.cpu is a fixed core count (CPU-fallback safety on the GPU host).
-    test.isEqual(4, spec.onGPU.cpu)
-
-    // onGPU.ram = 6*size + 2GiB bounded to [4, 64] GiB; fallback 16GiB
-    test.isEqual(_gib(4),  _eval(spec.onGPU.ram, F, 0, 0))          // floor
-    test.isEqual(_gib(64), _eval(spec.onGPU.ram, F, 100 * _gib(1), 0)) // cap
-    test.isEqual(_gib(16), f.fallbackOf(spec.onGPU.ram))
-
-    // onGPU.vram = 8*size + 2GiB bounded to [6, 48] GiB; fallback 16GiB
-    test.isEqual(_gib(6),  _eval(spec.onGPU.vram, F, 0, 0))          // floor
-    test.isEqual(_gib(48), _eval(spec.onGPU.vram, F, 100 * _gib(1), 0)) // cap
-    test.isEqual(_gib(16), f.fallbackOf(spec.onGPU.vram))
+    // No onGPU assertions here: 63052ff commented the onGPU block out of
+    // resource-formula.lib.tengo, so spec.onGPU is undefined. Tengo yields
+    // undefined for undefined[key] rather than erroring, so a stale assertion on
+    // spec.onGPU.cpu fails with "got <undefined>". Restore these alongside the lib
+    // block, not before it.
 }
 
 // -------- resourcesSeqFeatures: lineCount-driven (clonotype count) ----------
@@ -82,17 +75,7 @@ TestResourcesSeqFeatures := func() {
     test.isEqual(_gib(128), _eval(spec.onCPU.ram, F, 0, 1000000000)) // cap
     test.isEqual(_gib(64),  f.fallbackOf(spec.onCPU.ram))
 
-    test.isEqual(4, spec.onGPU.cpu)
-
-    // onGPU.ram = 1024*lineCount + 2GiB bounded to [4, 64] GiB; fallback 16GiB
-    test.isEqual(_gib(4),  _eval(spec.onGPU.ram, F, 0, 1000))      // floor
-    test.isEqual(_gib(64), _eval(spec.onGPU.ram, F, 0, 1000000000)) // cap
-    test.isEqual(_gib(16), f.fallbackOf(spec.onGPU.ram))
-
-    // onGPU.vram = 512*lineCount + 2GiB bounded to [6, 48] GiB; fallback 16GiB
-    test.isEqual(_gib(6),  _eval(spec.onGPU.vram, F, 0, 1000))     // floor
-    test.isEqual(_gib(48), _eval(spec.onGPU.vram, F, 0, 1000000000)) // cap
-    test.isEqual(_gib(16), f.fallbackOf(spec.onGPU.vram))
+    // onGPU assertions omitted for the same reason as in TestResourcesEmbeddings.
 }
 
 // -------- apply: direct mode wires literal UI values -------------------------


### PR DESCRIPTION
`workflow/src/resource-formula.test.tengo` has been in this repo, complete and working, without ever running once. The workflow package had no `test` script — only `build`, `format`, `do-pack` and `check` — so nothing invoked it. Estate-wide there are two `.test.tengo` files across all of `blocks/` and zero invocations of either.

This adds the script and fixes what turning it on exposed.

## What running it for the first time revealed

Two of the four tests failed:

```
FAIL: TestResourcesEmbeddings   expect: 4, got <undefined>   (line 54)
FAIL: TestResourcesSeqFeatures  expect: 4, got <undefined>   (line 85)
```

Both assert `spec.onGPU.cpu`. The `onGPU` blocks were commented out of `resource-formula.lib.tengo` by 63052ff ("disable GPU on all levels") — deliberately, and only two days before this test was first executed. The test had drifted from its lib and nothing caught it, because nothing ran it. That is the whole argument for this PR: an unexecuted test is not a safety net, it is a decoration that gets stale.

## Why both GPU blocks are deleted rather than the two failing lines

Tengo returns `undefined` for `undefined[key]` instead of erroring. So removing only lines 54 and 85 leaves the following `onGPU.ram` and `onGPU.vram` assertions evaluating undefined formula nodes, and they fail in turn. Both whole blocks have to go together.

They are deleted, not revived. Uncommenting the lib blocks instead would revert a deliberate change made by someone else. The comment left in the test says to restore the assertions **alongside** the lib block whenever GPU is re-enabled, so the next person has the context rather than a mystery gap.

## What is now guarded

The four passing tests cover the CPU formulas on both paths — floors, caps and static fallbacks for the size-driven (`resourcesEmbeddings`, parquet byte size) and lineCount-driven (`resourcesSeqFeatures`, clonotype count) branches, plus `apply()`'s direct-mode wiring and its routing by `inputMode`.

## No CI change needed

The reusable workflow already sets `test: true` with `test-script-name: 'test'`, which runs the root `turbo run test`. Turbo picks up the new task in the workflow package automatically. `pl-tengo test` also needs no extra devDependency — `@platforma-sdk/tengo-builder` pulls the tester in transitively — and it exits 1 on failure, so it is a real gate rather than an advisory.

## Test plan

- `pnpm exec pl-tengo test ./src` before the fix: 4 tests run, **2 fail** with the output above, exit code **1**
- After: **4/4 pass**, exit code **0**
- `pnpm run test` via the new script: 4/4 pass
- `pnpm exec pl-tengo check`: clean
- `pnpm run build` in `workflow/`: clean, template pack builds
- `pnpm exec changeset status`: patch bump on the workflow package

## Pre-existing failure a reviewer will hit

`pnpm run build:dev` at the repo root fails before it reaches the workflow package:

```
model/src/index.ts(265,39): error TS2345: Argument of type 'Column[]' is not
assignable to parameter of type 'PColumn<PColumnDataUniversal>[]'
```

This is unrelated to this branch — reproduced with these changes stashed on an otherwise clean tree. Flagging it so it does not get attributed here; it deserves its own ticket.
